### PR TITLE
17 cpl aux component still has disabled components

### DIFF
--- a/tse_to_opendss/thcc_libs/component_scripts/comp_capacitor.py
+++ b/tse_to_opendss/thcc_libs/component_scripts/comp_capacitor.py
@@ -69,8 +69,11 @@ def y_delta_connection(mdl, comp_handle, tp_connection, phases):
     delta_conn_2 = mdl.get_item('delta_conn_2', parent=comp_handle, item_type="connection")
     b1_conn = mdl.get_item('b1_conn', parent=comp_handle, item_type="connection")
     b1 = mdl.get_item('B1', parent=comp_handle, item_type="port")
-    c1_conn = mdl.get_item('c1_conn', parent=comp_handle, item_type="connection")
     c1 = mdl.get_item('C1', parent=comp_handle, item_type="port")
+    if cap_c and c1:
+        c1_conn_list = mdl.find_connections(c1, mdl.term(cap_c, "p_node"))
+    else:
+        c1_conn_list = []
     gndc = mdl.get_item("gndc", parent=comp_handle)
 
     if b1_conn:
@@ -92,17 +95,17 @@ def y_delta_connection(mdl, comp_handle, tp_connection, phases):
         mdl.create_connection(mdl.term(cap_a, "p_node"), mdl.term(cap_b, "n_node"), name="delta_conn_1")
         mdl.create_connection(mdl.term(cap_c, "p_node"), mdl.term(cap_b, "p_node"), name="delta_conn_2")
         mdl.create_connection(junc, b1, name="b1_conn")
-        c1_conn = mdl.get_item('c1_conn', parent=comp_handle, item_type="connection")
-        if not c1_conn:
-            mdl.create_connection(c1, mdl.term(cap_c, "p_node"), name="c1_conn")
+        if len(c1_conn_list) == 0:
+            mdl.create_connection(c1, mdl.term(cap_c, "p_node"))
 
     elif tp_connection == "Y" or tp_connection == "Y-grounded":
         if delta_conn_1:
             mdl.delete_item(delta_conn_1)
         if delta_conn_2:
             mdl.delete_item(delta_conn_2)
-        if c1_conn:
-            mdl.delete_item(c1_conn)
+        if len(c1_conn_list) > 0:
+            for c1_conn in c1_conn_list:
+                mdl.delete_item(c1_conn)
 
         if phases == "1":
             mdl.create_connection(junc, mdl.term(cap_a, "n_node"))
@@ -191,9 +194,8 @@ def redo_connections(mdl, mask_handle):
             if not b1_conn:
                 mdl.create_connection(b1, mdl.term(cap_b, "p_node"), name="b1_conn")
 
-            c1_conn = mdl.get_item('c1_conn', parent=comp_handle, item_type="connection")
-            if not c1_conn:
-                mdl.create_connection(c1, mdl.term(cap_c, "p_node"), name="c1_conn")
+            if len(mdl.find_connections(c1, mdl.term(cap_c, "p_node"))) == 0:
+                mdl.create_connection(c1, mdl.term(cap_c, "p_node"))
 
             mdl.create_connection(a2, mdl.term(cap_a, "n_node"))
             mdl.create_connection(b2, mdl.term(cap_b, "n_node"))

--- a/tse_to_opendss/thcc_libs/component_scripts/comp_fault.py
+++ b/tse_to_opendss/thcc_libs/component_scripts/comp_fault.py
@@ -65,7 +65,7 @@ def update_inner_gnd(mdl, mask_handle, created_ports):
     gnd_connection = True if "GND" in mdl.get_property_value(type_prop) else False
 
     if gnd_connection:
-        if av_gnd and not (len(mdl.get_connected_items(av_gnd)) > 0):
+        if av_gnd and not (len(mdl.find_connections(av_gnd)) > 0):
             mdl.create_connection(av_gnd, mdl.term(inner_fault, 'GND'))
 
 

--- a/tse_to_opendss/thcc_libs/opendss_lib.tlib
+++ b/tse_to_opendss/thcc_libs/opendss_lib.tlib
@@ -6733,6 +6733,22 @@ if (Vdc<-2) {
 
         component Subsystem Load {
             layout = static
+            component "OpenDSS/CIL" CIL {
+                VAB = "Vn_3ph_CPL*1000"
+                VAn = "Vn_3ph_CPL*1000/(3**0.5)"
+                VBC = "Vn_3ph_CPL*1000"
+                VBn = "Vn_3ph_CPL*1000/(3**0.5)"
+                VCA = "Vn_3ph_CPL*1000"
+                VCn = "Vn_3ph_CPL*1000/(3**0.5)"
+                pf_modeA = "Lead"
+                pf_modeB = "Lead"
+                pf_modeC = "Lead"
+                pf_mode_3ph = "Lead"
+            }
+            [
+                position = 7920, 8208
+                size = 96, 64
+            ]
 
             port A1 {
                 position = -30, -32
@@ -6745,7 +6761,7 @@ if (Vdc<-2) {
             ]
 
             port B1 {
-                position = 0.0, -32.0
+                position = 0.0, -32
                 kind = pe
                 direction =  in
             }
@@ -6765,7 +6781,7 @@ if (Vdc<-2) {
             ]
 
             port N1 {
-                position = 0, 30
+                position = 0.0, 30.0
                 kind = pe
                 direction =  in
             }
@@ -6813,7 +6829,7 @@ if (Vdc<-2) {
                 kind = pe
             }
             [
-                position = 7696, 8088
+                position = 7856, 8088
                 rotation = right
                 size = 60, 20
             ]
@@ -6824,7 +6840,7 @@ if (Vdc<-2) {
                 kind = pe
             }
             [
-                position = 7760, 8088
+                position = 7920, 8088
                 rotation = right
                 size = 60, 20
             ]
@@ -6835,7 +6851,7 @@ if (Vdc<-2) {
                 kind = pe
             }
             [
-                position = 7824, 8088
+                position = 7984, 8088
                 rotation = right
                 size = 60, 20
             ]
@@ -6849,14 +6865,14 @@ if (Vdc<-2) {
             connect B1 TagB1 as ConnB1P
             connect C1 TagC1 as ConnC1P
             connect JN N1 as Conn_N0
+            connect CIL.A1 TagA2 as Connection1
+            connect CIL.N JN as Conn_AN
+            connect CIL.B1 TagB2 as Connection2
+            connect CIL.C1 TagC2 as Connection3
 
-            Pow_ref_s = "Fixed"
             Sn_3ph = "3500"
             T_mode = "Loadshape index"
             Vn_3ph = "4.16"
-            global_basefreq = "True"
-            ground_connected = "False"
-            load_model = "Constant Impedance"
             pf_mode_3ph = "Lag"
 
             mask {
@@ -6892,6 +6908,7 @@ if (Vdc<-2) {
                     default_value = "60"
                     unit = "Hz"
                     group = "General:1"
+                    nonvisible
                 }
 
                 conn_type {
@@ -6929,7 +6946,6 @@ if (Vdc<-2) {
                     no_evaluate
 
                     CODE property_value_changed
-
                         mdl.refresh_icon(container_handle)
 
                         comp_script = return_comp_script(mdl, container_handle)
@@ -7037,7 +7053,6 @@ if (Vdc<-2) {
                     no_evaluate
 
                     CODE property_value_changed
-
                         if new_value == "Constant Power":
                             mdl.info("Warning: Load Constant Power mode demands grounding for correct HIL simulation.")
 
@@ -7072,7 +7087,6 @@ if (Vdc<-2) {
                     no_evaluate
 
                     CODE property_value_changed
-
                         comp_script = return_comp_script(mdl, container_handle)
                         ports = comp_script.port_dynamics(mdl, container_handle)
                         comp_script.connections_pow_ref_dynamics(mdl, container_handle, ports)
@@ -7191,7 +7205,6 @@ if (Vdc<-2) {
                         old_value = mdl.get_property_value(prop_handle)
                         mdl.set_property_value(prop_handle, old_value)
                     ENDCODE
-
                 }
 
                 loadshape_from_file {
@@ -7222,15 +7235,14 @@ if (Vdc<-2) {
                     ENDCODE
                 }
 
-
                 loadshape_from_file_path {
                     label = "LoadShape from file - path"
                     widget = edit
                     type = generic
                     default_value = ""
                     group = "Time Series Settings:4"
-                    no_evaluate
                     nonvisible
+                    no_evaluate
                 }
 
                 loadshape_from_file_column {
@@ -7239,8 +7251,8 @@ if (Vdc<-2) {
                     type = generic
                     default_value = "1"
                     group = "Time Series Settings:4"
-                    no_evaluate
                     nonvisible
+                    no_evaluate
                 }
 
                 loadshape_from_file_header {
@@ -7249,8 +7261,8 @@ if (Vdc<-2) {
                     type = generic
                     default_value = "True"
                     group = "Time Series Settings:4"
-                    no_evaluate
                     nonvisible
+                    no_evaluate
                 }
 
                 loadshape {
@@ -7364,6 +7376,7 @@ if (Vdc<-2) {
                     default_value = "Daily"
                     group = "Time Series Settings"
                     nonvisible
+                    no_evaluate
                 }
 
                 T_Ts_internal {
@@ -7452,6 +7465,7 @@ if (Vdc<-2) {
                     type = bool
                     default_value = "False"
                     group = "Monitoring"
+                    no_evaluate
                 }
 
                 CODE open
@@ -7471,7 +7485,6 @@ if (Vdc<-2) {
                 ENDCODE
 
                 CODE pre_compile
-
                     comp_script = return_comp_script(mdl, item_handle)
                     comp_script.restore_all_loads_points(mdl, item_handle)
 
@@ -7659,7 +7672,6 @@ if (Vdc<-2) {
                 ENDCODE
 
                 CODE init
-
                     import os
                     import sys
                     import importlib
@@ -19827,7 +19839,7 @@ out = out_value;
             layout = dynamic
             component Subsystem CIL {
                 layout = static
-                component pas_resistor Ra {
+                component "core/Resistor" Ra {
                     resistance = "Ra"
                 }
                 [
@@ -19835,7 +19847,7 @@ out = out_value;
                     rotation = right
                 ]
 
-                component pas_resistor Rb {
+                component "core/Resistor" Rb {
                     resistance = "Rb"
                 }
                 [
@@ -19843,7 +19855,7 @@ out = out_value;
                     rotation = right
                 ]
 
-                component pas_resistor Rc {
+                component "core/Resistor" Rc {
                     resistance = "Rc"
                 }
                 [
@@ -19851,7 +19863,7 @@ out = out_value;
                     rotation = right
                 ]
 
-                component pas_capacitor Ca {
+                component "core/Capacitor" Ca {
                     capacitance = "Ca"
                 }
                 [
@@ -19859,7 +19871,7 @@ out = out_value;
                     rotation = right
                 ]
 
-                component pas_capacitor Cb {
+                component "core/Capacitor" Cb {
                     capacitance = "Cb"
                 }
                 [
@@ -19867,7 +19879,7 @@ out = out_value;
                     rotation = right
                 ]
 
-                component pas_capacitor Cc {
+                component "core/Capacitor" Cc {
                     capacitance = "Cc"
                 }
                 [
@@ -19906,7 +19918,7 @@ out = out_value;
                 ]
 
                 port N {
-                    position = 0, 30
+                    position = 0.0, 30.0
                     kind = pe
                     direction =  in
                 }
@@ -19960,19 +19972,28 @@ out = out_value;
                 connect JB1 JN as Conn_BN
                 connect JC1 JN as Conn_CN
                 connect JN N as Conn_N
-                connect Ca.n_node JA1 as Conn_A
                 connect Ra.n_node Ca.p_node as Conn_A0
-                connect Cb.n_node JB1 as Conn_B
                 connect Rb.n_node Cb.p_node as Conn_B0
-                connect Cc.n_node JC1 as Conn_C
                 connect Rc.n_node Cc.p_node as Conn_C0
+                connect Ca.n_node JA1 as Conn_A
+                connect Cb.n_node JB1 as Conn_B
+                connect Cc.n_node JC1 as Conn_C
 
-                SAB = "5000*1000/3"
-                SAn = "5000*1000/3"
-                SBC = "5000*1000/3"
-                SBn = "5000*1000/3"
-                SCA = "5000*1000/3"
-                SCn = "5000*1000/3"
+                SAB = "Sn_3ph*1000/3"
+                SAn = "Sn_3ph*1000/3"
+                SBC = "Sn_3ph*1000/3"
+                SBn = "Sn_3ph*1000/3"
+                SCA = "Sn_3ph*1000/3"
+                SCn = "Sn_3ph*1000/3"
+                VAB = "Vn_3ph_CPL*1000"
+                VAn = "Vn_3ph_CPL*1000/(3**0.5)"
+                VBC = "Vn_3ph_CPL*1000"
+                VBn = "Vn_3ph_CPL*1000/(3**0.5)"
+                VCA = "Vn_3ph_CPL*1000"
+                VCn = "Vn_3ph_CPL*1000/(3**0.5)"
+                pfA = "pf_3ph_set"
+                pfB = "pf_3ph_set"
+                pfC = "pf_3ph_set"
                 pf_modeA = "Lead"
                 pf_modeB = "Lead"
                 pf_modeC = "Lead"
@@ -21008,7 +21029,7 @@ out = out_value;
 
             component Subsystem CPL {
                 layout = dynamic
-                component src_constant Constant1 {
+                component "core/Constant" Constant1 {
                     execution_rate = "Ts"
                     value = "kP_tot"
                 }
@@ -21017,7 +21038,7 @@ out = out_value;
                     hide_name = True
                 ]
 
-                component src_constant Constant11 {
+                component "core/Constant" Constant11 {
                     execution_rate = "Ts"
                     value = "kQ_tot"
                 }
@@ -21026,7 +21047,7 @@ out = out_value;
                     hide_name = True
                 ]
 
-                component gen_gain Gain1 {
+                component "core/Gain" Gain1 {
                     gain = "inv_ph"
                 }
                 [
@@ -21034,7 +21055,7 @@ out = out_value;
                     hide_name = True
                 ]
 
-                component gen_gain Gain2 {
+                component "core/Gain" Gain2 {
                     gain = "inv_ph"
                 }
                 [
@@ -21060,7 +21081,7 @@ out = out_value;
                     size = 32, 32
                 ]
 
-                component gen_rate_limiter "Rate Limiter1" {
+                component "core/Rate Limiter" "Rate Limiter1" {
                     falling_limit = "-SS/Freq"
                     rising_limit = "SS/Freq"
                 }
@@ -21069,7 +21090,7 @@ out = out_value;
                     hide_name = True
                 ]
 
-                component gen_rate_limiter "Rate Limiter2" {
+                component "core/Rate Limiter" "Rate Limiter2" {
                     falling_limit = "-SS/Freq"
                     rising_limit = "SS/Freq"
                 }
@@ -21078,7 +21099,7 @@ out = out_value;
                     hide_name = True
                 ]
 
-                component src_constant Constant14 {
+                component "core/Constant" Constant14 {
                     execution_rate = "Ts"
                     value = "Pc_T"
                 }
@@ -21087,14 +21108,14 @@ out = out_value;
                     hide_name = True
                 ]
 
-                component gen_product Product23 {
+                component "core/Product" Product23 {
                 }
                 [
                     position = 8016, 7512
                     hide_name = True
                 ]
 
-                component gen_sum Sum10 {
+                component "core/Sum" Sum10 {
                     signs = "++"
                 }
                 [
@@ -21102,7 +21123,7 @@ out = out_value;
                     hide_name = True
                 ]
 
-                component src_constant Constant17 {
+                component "core/Constant" Constant17 {
                     execution_rate = "Ts"
                     value = "0.01*(Ts-600e-6)/Ts"
                 }
@@ -21111,7 +21132,7 @@ out = out_value;
                     hide_name = True
                 ]
 
-                component sys_signal_switch "Signal switch27" {
+                component "core/Signal switch" "Signal switch27" {
                     criterion = "ctrl >= threshold"
                     threshold = "0"
                 }
@@ -21120,7 +21141,7 @@ out = out_value;
                     hide_name = True
                 ]
 
-                component src_constant Constant18 {
+                component "core/Constant" Constant18 {
                     execution_rate = "Ts"
                     value = "0.005*(Ts-600e-6)/Ts"
                 }
@@ -21129,7 +21150,7 @@ out = out_value;
                     hide_name = True
                 ]
 
-                component gen_sum Sum14 {
+                component "core/Sum" Sum14 {
                     signs = "++"
                 }
                 [
@@ -21137,4940 +21158,38 @@ out = out_value;
                     hide_name = True
                 ]
 
-                component gen_sign Sign3 {
+                component "core/Sign" Sign3 {
                 }
                 [
                     position = 7856, 7616
                     hide_name = True
                 ]
 
-                component gen_product Product24 {
+                component "core/Product" Product24 {
                 }
                 [
                     position = 8008, 7680
                     hide_name = True
                 ]
 
-                component Subsystem CPL1 {
-                    layout = dynamic
-                    component gen_limiter Limit1 {
-                        lower_limit = "0.1"
-                    }
-                    [
-                        position = 7464, 8168
-                        hide_name = True
-                    ]
-
-                    component gen_product Product1 {
-                        signs = "*/"
-                    }
-                    [
-                        position = 7928, 8152
-                        hide_name = True
-                    ]
-
-                    component gen_product Product2 {
-                    }
-                    [
-                        position = 7544, 8176
-                        hide_name = True
-                    ]
-
-                    component gen_product Product3 {
-                    }
-                    [
-                        position = 8392, 8144
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_z_domain_transfer "Discrete Transfer Function1" {
-                        a_coeff = "[0.01,1]"
-                        b_coeff = "[1]"
-                        domain = "S-domain"
-                        method = "Euler"
-                    }
-                    [
-                        position = 8296, 8136
-                        hide_name = True
-                    ]
-
-                    component pas_resistor R1 {
-                        resistance = "Rsnb"
-                    }
-                    [
-                        position = 7976, 8888
-                    ]
-
-                    component "core/Signal Controlled Current Source" Isp1 {
-                    }
-                    [
-                        position = 7968, 8784
-                        scale = -1, 1
-                        size = 64, 32
-                    ]
-
-                    component "core/Voltage RMS" Varms {
-                        sig_output = "True"
-                    }
-                    [
-                        position = 7968, 9088
-                        size = 64, 32
-                    ]
-
-                    component "core/Voltage Measurement" Va {
-                        execution_rate = "inherit"
-                        sig_output = "True"
-                    }
-                    [
-                        position = 7968, 9200
-                        size = 64, 32
-                    ]
-
-                    component gen_limiter Limit2 {
-                    }
-                    [
-                        position = 8016, 8152
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch20" {
-                        criterion = "ctrl >= threshold"
-                    }
-                    [
-                        position = 8200, 8136
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain2 {
-                        gain = "1000"
-                    }
-                    [
-                        position = 7816, 8120
-                        hide_name = True
-                    ]
-
-                    component gen_comparator Comparator1 {
-                    }
-                    [
-                        position = 8168, 7984
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant2 {
-                        execution_rate = "Ts"
-                        value = "CPL_curr/(VLL*kVLL)"
-                    }
-                    [
-                        position = 7768, 8048
-                        hide_name = True
-                    ]
-
-                    component gen_product Product4 {
-                    }
-                    [
-                        position = 7856, 8072
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_gain Gain16 {
-                        gain = "-1"
-                    }
-                    [
-                        position = 8224, 7912
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit10 {
-                        upper_limit = "0"
-                    }
-                    [
-                        position = 8144, 7912
-                        hide_name = True
-                    ]
-
-                    component gen_sign Sign1 {
-                    }
-                    [
-                        position = 8288, 7912
-                        hide_name = True
-                    ]
-
-                    component gen_product Product19 {
-                        signs = "3"
-                    }
-                    [
-                        position = 8576, 7664
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit11 {
-                        lower_limit = "0"
-                    }
-                    [
-                        position = 7712, 7680
-                        hide_name = True
-                    ]
-
-                    component gen_sign Sign2 {
-                    }
-                    [
-                        position = 7776, 7680
-                        hide_name = True
-                    ]
-
-                    component gen_product Product14 {
-                        signs = "*/"
-                    }
-                    [
-                        position = 7992, 7832
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain15 {
-                        gain = "1000"
-                    }
-                    [
-                        position = 7888, 7824
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit7 {
-                        lower_limit = "0"
-                    }
-                    [
-                        position = 8064, 7832
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch23" {
-                        criterion = "ctrl >= threshold"
-                    }
-                    [
-                        position = 8272, 7816
-                        hide_name = True
-                    ]
-
-                    component gen_comparator Comparator4 {
-                    }
-                    [
-                        position = 8208, 7744
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_product Product15 {
-                    }
-                    [
-                        position = 7992, 7736
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant8 {
-                        execution_rate = "inherit"
-                        value = "CPL_curr/(VLL*kVLL)"
-                    }
-                    [
-                        position = 7896, 7760
-                        hide_name = True
-                    ]
-
-                    component gen_z_domain_transfer "Discrete Transfer Function4" {
-                        a_coeff = "[0.01,1]"
-                        b_coeff = "[1]"
-                        domain = "S-domain"
-                        method = "Euler"
-                    }
-                    [
-                        position = 8336, 7816
-                        hide_name = True
-                    ]
-
-                    component gen_product Product17 {
-                        signs = "3"
-                    }
-                    [
-                        position = 8560, 7912
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum5 {
-                        signs = "+++"
-                    }
-                    [
-                        position = 8768, 8208
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_abs Abs1 {
-                    }
-                    [
-                        position = 7712, 7728
-                        hide_name = True
-                    ]
-
-                    component gen_product Product20 {
-                    }
-                    [
-                        position = 6864, 7696
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain18 {
-                        gain = "Pc_pQ"
-                    }
-                    [
-                        position = 6976, 7696
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum8 {
-                        signs = "+++-"
-                    }
-                    [
-                        position = 7360, 7976
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_sign Sign3 {
-                    }
-                    [
-                        position = 6832, 7640
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch24" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 7088, 7712
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain19 {
-                        gain = "Pc_nQ"
-                    }
-                    [
-                        position = 6976, 7728
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain20 {
-                        gain = "1/(1000*Rsnb)"
-                    }
-                    [
-                        position = 7368, 7552
-                        hide_name = True
-                    ]
-
-                    component gen_product Product21 {
-                    }
-                    [
-                        position = 7112, 7368
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_gain Gain21 {
-                        gain = "nQc_P"
-                    }
-                    [
-                        position = 7208, 7368
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum9 {
-                        signs = "+++++"
-                    }
-                    [
-                        position = 7496, 7600
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit12 {
-                        lower_limit = "0"
-                    }
-                    [
-                        position = 7008, 7416
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch25" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 7368, 7384
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_gain Gain22 {
-                        gain = "pQc_P"
-                    }
-                    [
-                        position = 7208, 7400
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant14 {
-                        execution_rate = "Ts"
-                        value = "Pc_T_pQ"
-                    }
-                    [
-                        position = 6864, 7816
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch26" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 6976, 7840
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant15 {
-                        execution_rate = "Ts"
-                        value = "Pc_T_nQ"
-                    }
-                    [
-                        position = 6864, 7856
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant17 {
-                        execution_rate = "Ts"
-                        value = "pQc_T"
-                    }
-                    [
-                        position = 6920, 7496
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch27" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 7008, 7520
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant18 {
-                        execution_rate = "Ts"
-                        value = "nQc_T"
-                    }
-                    [
-                        position = 6920, 7536
-                        hide_name = True
-                    ]
-
-                    component gen_abs Abs2 {
-                    }
-                    [
-                        position = 8080, 7976
-                        hide_name = True
-                    ]
-
-                    component gen_abs Abs3 {
-                    }
-                    [
-                        position = 8120, 8032
-                        rotation = left
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum14 {
-                        signs = "+-"
-                    }
-                    [
-                        position = 6416, 7416
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant19 {
-                        execution_rate = "Ts"
-                        value = "60"
-                    }
-                    [
-                        position = 6320, 7456
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum15 {
-                        signs = "+-"
-                    }
-                    [
-                        position = 6568, 7360
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant20 {
-                        execution_rate = "Ts"
-                    }
-                    [
-                        position = 6488, 7352
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain24 {
-                        gain = "Fc"
-                    }
-                    [
-                        position = 6488, 7416
-                        hide_name = True
-                    ]
-
-                    component "core/Edge Detection" "Edge Detection1" {
-                    }
-                    [
-                        position = 9216, 8328
-                        rotation = right
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component "core/Rate Transition" "Rate Transition1" {
-                        execution_rate = "Tfst"
-                    }
-                    [
-                        position = 8848, 8280
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component gen_c_function "C function1" {
-                        global_variables = "real counter;real m0;real m1;real m2;real corr;"
-                        init_fnc = "/*Begin code section*/
-counter=0;
-/*End code section*/"
-                        input_terminals = "real sync;real z;real zi;real zii;real Ts;real Ts_fast;"
-                        input_terminals_dimensions = "inherit;inherit;inherit;inherit;inherit;inherit"
-                        input_terminals_feedthrough = "True;True;True;True;True;True"
-                        input_terminals_show_labels = "True;True;True;True;True;True"
-                        output_fnc = "/*Begin code section*/
-counter = counter + Ts_fast;
-if (sync > 0 ) {
-    out = z;
-    counter = 0;
-
-}
-else {
-    corr = 1 - 0.11 * (Ts - Ts_fast)/Ts;
-    m2 = (zi - zii)/Ts;
-    m1 = (z - zi)/Ts;
-    m0 = m1 + (m1-m2);
-
-    out = z + counter * corr * m0;
-}
-
-if (counter >= Ts) {
-    counter = 0;
-}
-/*End code section*/"
-                        output_terminals_dimensions = "inherit"
-                        output_terminals_feedthrough = "True"
-                        output_terminals_show_labels = "True"
-                    }
-                    [
-                        position = 9144, 8536
-                        rotation = right
-                        hide_name = True
-                        size = 48, 128
-                    ]
-
-                    component tm_delay "Unit Delay9" {
-                    }
-                    [
-                        position = 8848, 8344
-                        hide_name = True
-                    ]
-
-                    component tm_delay "Unit Delay10" {
-                    }
-                    [
-                        position = 8952, 8400
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant21 {
-                        execution_rate = "Tfst"
-                        value = "Ts"
-                    }
-                    [
-                        position = 9080, 8448
-                        hide_name = True
-                    ]
-
-                    component "core/Rate Transition" "Rate Transition2" {
-                        execution_rate = "Tfst"
-                    }
-                    [
-                        position = 8952, 8344
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component "core/Rate Transition" "Rate Transition3" {
-                        execution_rate = "Tfst"
-                    }
-                    [
-                        position = 9032, 8400
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component sys_signal_switch "Signal switch28" {
-                        threshold = "Tfst"
-                    }
-                    [
-                        position = 9296, 8648
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component src_constant Constant22 {
-                        execution_rate = "Tfst"
-                        value = "Ts"
-                    }
-                    [
-                        position = 9248, 8704
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch29" {
-                    }
-                    [
-                        position = 9392, 8608
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component src_constant Constant23 {
-                        execution_rate = "Tfst"
-                        value = "Tfast_en"
-                    }
-                    [
-                        position = 9336, 8696
-                        hide_name = True
-                    ]
-
-                    component gen_product Product22 {
-                    }
-                    [
-                        position = 7120, 7512
-                        hide_name = True
-                    ]
-
-                    component gen_product Product23 {
-                    }
-                    [
-                        position = 7088, 7848
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant24 {
-                        execution_rate = "Ts"
-                        value = "pQc_Q"
-                    }
-                    [
-                        position = 7112, 7264
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant25 {
-                        execution_rate = "Ts"
-                        value = "nQc_Q"
-                    }
-                    [
-                        position = 7112, 7216
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch30" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 7184, 7248
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_product Product24 {
-                    }
-                    [
-                        position = 7336, 7256
-                        hide_name = True
-                    ]
-
-                    component gen_terminator Termination70 {
-                    }
-                    [
-                        position = 7784, 8224
-                        rotation = left
-                        hide_name = True
-                    ]
-
-                    component gen_terminator Termination71 {
-                    }
-                    [
-                        position = 7816, 8264
-                        rotation = left
-                        hide_name = True
-                    ]
-
-                    component gen_terminator Termination72 {
-                    }
-                    [
-                        position = 7792, 8408
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain26 {
-                        gain = "1/(1000*Rsnb)"
-                    }
-                    [
-                        position = 7272, 7928
-                        hide_name = True
-                    ]
-
-                    component "core/Single phase PLL" "Single phase PLL1" {
-                        k_SOGI = "0.6"
-                        kd_PLL_HIGH = "0"
-                        kd_PLL_LOW = "0"
-                        kp_PLL_HIGH = "65.7"
-                        kp_PLL_LOW = "5.81e2"
-                        offset_Hz = "Freq"
-                    }
-                    [
-                        position = 7728, 8320
-                        hide_name = True
-                        size = 64, 98
-                    ]
-
-                    component gen_trigonometric "Trigonometric function1" {
-                    }
-                    [
-                        position = 8024, 8224
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain25 {
-                        gain = "1.41421356"
-                    }
-                    [
-                        position = 8192, 8264
-                        hide_name = True
-                    ]
-
-                    component gen_product Product25 {
-                    }
-                    [
-                        position = 8304, 8232
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component pas_capacitor C1 {
-                        capacitance = "1/(Rsnb*2*np.pi*Freq)"
-                    }
-                    [
-                        position = 7976, 8984
-                    ]
-
-                    component gen_trigonometric "Trigonometric function2" {
-                    }
-                    [
-                        position = 8192, 8344
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum16 {
-                        signs = "++"
-                    }
-                    [
-                        position = 8112, 8344
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant26 {
-                        execution_rate = "Ts"
-                        value = "-np.pi/2"
-                    }
-                    [
-                        position = 8016, 8360
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant28 {
-                        execution_rate = "Tfst"
-                        value = "Tfst"
-                    }
-                    [
-                        position = 9040, 8472
-                        hide_name = True
-                    ]
-
-                    component gen_product Product26 {
-                        signs = "**"
-                    }
-                    [
-                        position = 8408, 8352
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum17 {
-                        signs = "++"
-                    }
-                    [
-                        position = 8112, 8432
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant27 {
-                        execution_rate = "Ts"
-                        value = "np.pi/2"
-                    }
-                    [
-                        position = 8000, 8456
-                        hide_name = True
-                    ]
-
-                    component gen_trigonometric "Trigonometric function3" {
-                    }
-                    [
-                        position = 8192, 8432
-                        hide_name = True
-                    ]
-
-                    component gen_product Product27 {
-                        signs = "**"
-                    }
-                    [
-                        position = 8304, 8424
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    port P2 {
-                        position = right:2
-                        kind = pe
-                    }
-                    [
-                        position = 8192, 8784
-                        rotation = down
-                    ]
-
-                    port P3 {
-                        position = left:1
-                        kind = pe
-                    }
-                    [
-                        position = 7760, 8784
-                    ]
-
-                    port P {
-                        position = top:1
-                        kind = sp
-                        direction =  out
-                        sp_type {
-                            default = auto
-                            readonly = True
-                        }
-                    }
-                    [
-                        position = 6288, 7592
-                    ]
-
-                    port Q {
-                        position = top:2
-                        kind = sp
-                        direction =  out
-                        sp_type {
-                            default = auto
-                            readonly = True
-                        }
-                    }
-                    [
-                        position = 6288, 7664
-                    ]
-
-                    tag Goto1 {
-                        value = "ws"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 7888, 8320
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From1 {
-                        value = "ws"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6320, 7408
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag Goto2 {
-                        value = "kP"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 6368, 7592
-                        size = 60, 20
-                    ]
-
-                    tag Goto3 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 6368, 7664
-                        size = 60, 20
-                    ]
-
-                    tag From2 {
-                        value = "kP"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7288, 7888
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From3 {
-                        value = "kP"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6920, 7416
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From4 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7432, 7440
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From5 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6712, 7640
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From6 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7000, 7896
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From7 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7248, 7264
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag Goto4 {
-                        value = "Va"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 7912, 9152
-                        rotation = down
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From8 {
-                        value = "Va"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7616, 8320
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From9 {
-                        value = "Va_rms"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 8104, 8264
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From10 {
-                        value = "Va_rms"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7376, 8168
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag Goto5 {
-                        value = "Va_rms"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 7912, 9048
-                        rotation = down
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag Goto6 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 7680, 8176
-                        hide_name = True
-                        size = 100, 20
-                    ]
-
-                    tag From11 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7816, 8176
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag From12 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7248, 7552
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag From13 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7160, 7928
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag From14 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7872, 7856
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag Goto7 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 6912, 7640
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From15 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7312, 7440
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From16 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7120, 7312
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From17 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6952, 7448
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From18 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6928, 7768
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From19 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7032, 7664
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag Goto8 {
-                        value = "Ia_load"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 9528, 8608
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From20 {
-                        value = "Ia_load"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7896, 8744
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    junction Junction1 sp
-                    [
-                        position = 7496, 8168
-                    ]
-
-                    junction Junction2 pe
-                    [
-                        position = 8080, 8784
-                    ]
-
-                    junction Junction10 sp
-                    [
-                        position = 8048, 8152
-                    ]
-
-                    junction Junction11 sp
-                    [
-                        position = 8120, 8072
-                    ]
-
-                    junction Junction62 sp
-                    [
-                        position = 7496, 7728
-                    ]
-
-                    junction Junction50 sp
-                    [
-                        position = 8144, 7832
-                    ]
-
-                    junction Junction51 sp
-                    [
-                        position = 8112, 7736
-                    ]
-
-                    junction Junction74 sp
-                    [
-                        position = 7856, 7728
-                    ]
-
-                    junction Junction78 sp
-                    [
-                        position = 6928, 7696
-                    ]
-
-                    junction Junction82 sp
-                    [
-                        position = 7496, 7680
-                    ]
-
-                    junction Junction84 sp
-                    [
-                        position = 7160, 7368
-                    ]
-
-                    junction Junction92 sp
-                    [
-                        position = 7760, 8120
-                    ]
-
-                    junction Junction95 sp
-                    [
-                        position = 6656, 7360
-                    ]
-
-                    junction Junction96 sp
-                    [
-                        position = 6784, 7640
-                    ]
-
-                    junction Junction97 pe
-                    [
-                        position = 7856, 8784
-                    ]
-
-                    junction Junction101 sp
-                    [
-                        position = 9168, 8280
-                    ]
-
-                    junction Junction102 sp
-                    [
-                        position = 8768, 8280
-                    ]
-
-                    junction Junction109 sp
-                    [
-                        position = 8912, 8344
-                    ]
-
-                    junction Junction112 sp
-                    [
-                        position = 7056, 7416
-                    ]
-
-                    junction Junction130 pe
-                    [
-                        position = 7856, 8888
-                    ]
-
-                    junction Junction131 pe
-                    [
-                        position = 8080, 8888
-                    ]
-
-                    junction Junction133 sp
-                    [
-                        position = 8376, 7816
-                    ]
-
-                    junction Junction121 sp
-                    [
-                        position = 8248, 8264
-                    ]
-
-                    junction Junction127 sp
-                    [
-                        position = 8248, 8360
-                    ]
-
-                    junction Junction129 sp
-                    [
-                        position = 7960, 8336
-                    ]
-
-                    junction Junction137 pe
-                    [
-                        position = 8080, 8984
-                    ]
-
-                    junction Junction138 pe
-                    [
-                        position = 7856, 8984
-                    ]
-
-                    junction Junction139 pe
-                    [
-                        position = 8080, 9088
-                    ]
-
-                    junction Junction140 pe
-                    [
-                        position = 7856, 9088
-                    ]
-
-                    junction Junction141 sp
-                    [
-                        position = 7960, 8336
-                    ]
-
-                    junction Junction142 sp
-                    [
-                        position = 9248, 8592
-                    ]
-
-                    junction Junction143 sp
-                    [
-                        position = 9216, 8280
-                    ]
-
-                    connect Limit1.out Junction1 as Connection9
-                    connect Junction1 Product2.in1 as Connection10
-                    connect "Discrete Transfer Function1.out" Product3.in1 as Connection16
-                    connect Product1.out Limit2.in as Connection44
-                    connect Gain2.out Product1.in as Connection47
-                    connect Constant2.out Product4.in1 as Connection54
-                    connect Comparator1.out "Signal switch20.in2" as Connection57
-                    connect Junction10 Limit2.out as Connection59
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Signal switch20.in1" Junction10 as Connection60
-                    connect Product4.out Junction11 as Connection62
-                    connect "Signal switch20.in" Junction11 as Connection64
-                    connect Limit10.out Gain16.in as Connection299
-                    connect Gain16.out Sign1.in as Connection315
-                    connect Limit10.in Junction62 as Connection319
-                    [
-                        position = 0, 0
-                    ]
-                    connect Limit11.out Sign2.in as Connection320
-                    connect Gain15.out Product14.in as Connection227
-                    connect Product14.out Limit7.in as Connection228
-                    connect Comparator4.out "Signal switch23.in2" as Connection229
-                    connect Limit7.out Junction50 as Connection233
-                    connect Junction50 "Signal switch23.in1" as Connection234
-                    connect Comparator4.in1 Junction50 as Connection235
-                    connect "Signal switch23.in" Junction51 as Connection236
-                    connect Product15.out Junction51 as Connection238
-                    connect Constant8.out Product15.in1 as Connection239
-                    connect "Signal switch23.out" "Discrete Transfer Function4.in" as Connection243
-                    connect Junction51 Comparator4.in2 as Connection253
-                    [
-                        position = 0, 0
-                    ]
-                    connect Abs1.in Junction62 as Connection395
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product15.in Junction74 as Connection396
-                    connect Junction74 Abs1.out as Connection397
-                    connect Gain15.in Junction74 as Connection398
-                    connect "Signal switch24.in" Gain18.out as Connection419
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Signal switch24.out" Sum8.in as Connection420
-                    connect Gain19.out "Signal switch24.in1" as Connection422
-                    connect Product20.out Junction78 as Connection423
-                    connect Junction78 Gain18.in as Connection424
-                    connect Gain19.in Junction78 as Connection425
-                    connect Product19.in2 Sign2.out as Connection430
-                    [
-                        position = 0, 0
-                    ]
-                    connect Limit11.in Junction82 as Connection444
-                    connect Junction82 Junction62 as Connection445
-                    [
-                        position = 0, 0
-                    ]
-                    connect Sum9.out Junction82 as Connection446
-                    connect Product21.out Junction84 as Connection461
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction84 Gain21.in as Connection462
-                    connect Gain22.in Junction84 as Connection463
-                    connect Gain22.out "Signal switch25.in" as Connection464
-                    connect Gain21.out "Signal switch25.in1" as Connection468
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction92 Gain2.in as Connection509
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product4.in Junction92 as Connection510
-                    connect Comparator1.in1 Abs2.out as Connection511
-                    connect Abs2.in Junction10 as Connection512
-                    connect Junction11 Abs3.in as Connection513
-                    connect Abs3.out Comparator1.in2 as Connection514
-                    connect Junction92 Sum8.out as Connection515
-                    [
-                        position = 0, 0
-                    ]
-                    connect From1 Sum14.in as Connection523
-                    connect Constant19.out Sum14.in1 as Connection524
-                    connect Constant20.out Sum15.in as Connection525
-                    connect Gain24.in Sum14.out as Connection526
-                    connect Gain24.out Sum15.in1 as Connection527
-                    connect Sum15.out Junction95 as Connection529
-                    connect P Goto2 as Connection532
-                    connect Q Goto3 as Connection533
-                    connect From3 Limit12.in as Connection535
-                    connect Sign3.in Junction96 as Connection538
-                    connect Junction96 Product20.in as Connection539
-                    [
-                        position = 0, 0
-                    ]
-                    connect From5 Junction96 as Connection540
-                    connect "Signal switch20.out" "Discrete Transfer Function1.in" as Connection554
-                    connect Constant21.out "C function1.Ts" as Connection605
-                    connect Junction101 "C function1.z" as Connection607
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Rate Transition3.in" "Unit Delay10.out" as Connection615
-                    connect "Rate Transition2.out" "C function1.zi" as Connection616
-                    connect "Rate Transition3.out" "C function1.zii" as Connection617
-                    connect "C function1.sync" "Edge Detection1.Out1" as Connection618
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Rate Transition1.in" Junction102 as Connection622
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant22.out "Signal switch28.in2" as Connection624
-                    connect Sum5.out Junction102 as Connection649
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant23.out "Signal switch29.in2" as Connection653
-                    connect "Signal switch28.out" "Signal switch29.in" as Connection660
-                    [
-                        position = 0, 0
-                    ]
-                    connect Isp1.p_node Junction2 as Connection670
-                    [
-                        position = 0, 0
-                    ]
-                    connect Isp1.n_node Junction97 as Connection669
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction102 "Unit Delay9.in" as Connection683
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Rate Transition2.in" Junction109 as Connection684
-                    connect Junction109 "Unit Delay9.out" as Connection685
-                    connect "Unit Delay10.in" Junction109 as Connection686
-                    connect Junction95 Product21.in1 as Connection697
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Signal switch27.out" Product22.in1 as Connection701
-                    connect Product21.in Junction112 as Connection704
-                    connect Junction112 Limit12.out as Connection705
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product22.in Junction112 as Connection706
-                    connect Product23.in "Signal switch26.out" as Connection710
-                    connect From6 Product23.in1 as Connection711
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant24.out "Signal switch30.in" as Connection713
-                    connect Constant25.out "Signal switch30.in1" as Connection714
-                    connect "Single phase PLL1.f" Goto1 as Connection881
-                    connect "Signal switch30.out" Product24.in as Connection718
-                    connect From7 Product24.in1 as Connection719
-                    connect "Single phase PLL1.d" Termination70.in as Connection882
-                    connect "Single phase PLL1.q" Termination71.in as Connection883
-                    connect Product20.in1 Junction95 as Connection721
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Single phase PLL1.sin(wt)" Termination72.in as Connection884
-                    connect "Signal switch28.in" "C function1.out" as Connection724
-                    [
-                        position = 0, 0
-                    ]
-                    connect Gain20.out Sum9.in4 as Connection869
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant17.out "Signal switch27.in" as Connection875
-                    connect Constant18.out "Signal switch27.in1" as Connection876
-                    connect Constant14.out "Signal switch26.in" as Connection878
-                    connect Constant15.out "Signal switch26.in1" as Connection879
-                    connect Product3.in Product25.out as Connection767
-                    connect Constant26.out Sum16.in1 as Connection771
-                    connect Sum16.out "Trigonometric function2.in" as Connection772
-                    connect "Trigonometric function1.out" Product25.in1 as Connection773
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant28.out "C function1.Ts_fast" as Connection837
-                    connect R1.p_node Junction130 as Connection838
-                    connect Junction130 Junction97 as Connection839
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction131 Junction2 as Connection842
-                    [
-                        position = 0, 0
-                    ]
-                    connect R1.n_node Junction131 as Connection843
-                    connect Product25.in Junction121 as Connection786
-                    connect "Discrete Transfer Function4.out" Junction133 as Connection847
-                    connect Junction121 Gain25.out as Connection787
-                    connect Product17.in Junction133 as Connection849
-                    connect "Trigonometric function2.out" Product26.in as Connection793
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product19.in1 Junction133 as Connection860
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant27.out Sum17.in1 as Connection800
-                    connect Junction1 Product2.in as Connection866
-                    [
-                        position = 0, 0
-                    ]
-                    connect Sum17.out "Trigonometric function3.in" as Connection808
-                    connect "Trigonometric function3.out" Product27.in as Connection809
-                    connect Product26.in1 Junction127 as Connection813
-                    connect Junction127 Junction121 as Connection814
-                    connect Product27.in1 Junction127 as Connection815
-                    connect Product19.in Product26.out as Connection818
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Trigonometric function1.in" Junction129 as Connection823
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Single phase PLL1.wt" Junction129 as Connection825
-                    connect Product22.out Sum9.in3 as Connection889
-                    connect From4 Sum9.in2 as Connection890
-                    connect "Signal switch25.out" Sum9.in1 as Connection891
-                    connect Product24.out Sum9.in as Connection892
-                    connect Gain26.out Sum8.in3 as Connection894
-                    connect C1.n_node Junction137 as Connection896
-                    connect Junction137 Junction131 as Connection897
-                    connect C1.p_node Junction138 as Connection900
-                    connect Junction138 Junction130 as Connection901
-                    connect P2 Junction2 as Connection903
-                    connect Varms.n_node Junction139 as Connection904
-                    connect Junction139 Junction137 as Connection905
-                    connect Va.n_node Junction139 as Connection906
-                    connect P3 Junction97 as Connection907
-                    connect Varms.p_node Junction140 as Connection908
-                    connect Junction140 Junction138 as Connection909
-                    connect Va.p_node Junction140 as Connection910
-                    connect Goto4 Va.out as Connection914
-                    connect From8 "Single phase PLL1.In" as Connection915
-                    connect From9 Gain25.in as Connection917
-                    connect Limit1.in From10 as Connection918
-                    connect Goto5 Varms.out as Connection919
-                    connect Sum16.in Junction141 as Connection921
-                    [
-                        position = 0, 0
-                        breakpoints = 7984, 8336
-                    ]
-                    connect Junction141 Junction129 as Connection922
-                    connect Sum17.in Junction141 as Connection923
-                    connect Sign1.out Product17.in1 as Connection925
-                    connect Product27.out Product17.in2 as Connection926
-                    connect From11 Product1.in1 as Connection931
-                    connect From12 Gain20.in as Connection933
-                    connect From13 Gain26.in as Connection935
-                    connect Goto6 Product2.out as Connection936
-                    connect From14 Product14.in1 as Connection937
-                    connect From15 "Signal switch25.in2" as Connection942
-                    connect From16 "Signal switch30.in2" as Connection944
-                    connect From17 "Signal switch27.in2" as Connection946
-                    connect Goto7 Sign3.out as Connection947
-                    connect From18 "Signal switch26.in2" as Connection948
-                    connect From19 "Signal switch24.in2" as Connection949
-                    connect Product23.out Sum8.in1 as Connection950
-                    connect From2 Sum8.in2 as Connection951
-                    connect Product3.out Sum5.in2 as Connection952
-                    connect Product17.out Sum5.in1 as Connection953
-                    connect Product19.out Sum5.in as Connection954
-                    connect Junction101 "Rate Transition1.out" as Connection956
-                    connect "Signal switch28.in1" Junction142 as Connection957
-                    connect Junction142 "Signal switch29.in1" as Connection958
-                    connect Junction101 Junction143 as Connection959
-                    connect Junction143 "Edge Detection1.In1" as Connection960
-                    connect Junction142 Junction143 as Connection961
-                    connect Goto8 "Signal switch29.out" as Connection965
-                    connect From20 Isp1.in as Connection966
+                component "OpenDSS/single-phase CPL" CPLA {
                 }
                 [
-                    position = 8040, 8024
+                    position = 8032, 8008
                     size = 48, 48
                 ]
 
-                component Subsystem CPL2 {
-                    layout = dynamic
-                    component gen_limiter Limit1 {
-                        lower_limit = "0.1"
-                    }
-                    [
-                        position = 7296, 8584
-                        hide_name = True
-                    ]
-
-                    component gen_product Product1 {
-                        signs = "*/"
-                    }
-                    [
-                        position = 7760, 8568
-                        hide_name = True
-                    ]
-
-                    component gen_product Product2 {
-                    }
-                    [
-                        position = 7376, 8592
-                        hide_name = True
-                    ]
-
-                    component gen_product Product3 {
-                    }
-                    [
-                        position = 8224, 8560
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_z_domain_transfer "Discrete Transfer Function1" {
-                        a_coeff = "[0.01,1]"
-                        b_coeff = "[1]"
-                        domain = "S-domain"
-                        method = "Euler"
-                    }
-                    [
-                        position = 8128, 8552
-                        hide_name = True
-                    ]
-
-                    component pas_resistor R1 {
-                        resistance = "Rsnb"
-                    }
-                    [
-                        position = 7808, 9304
-                    ]
-
-                    component "core/Signal Controlled Current Source" Isp1 {
-                    }
-                    [
-                        position = 7800, 9200
-                        scale = -1, 1
-                        size = 64, 32
-                    ]
-
-                    component "core/Voltage RMS" Varms {
-                        sig_output = "True"
-                    }
-                    [
-                        position = 7800, 9504
-                        size = 64, 32
-                    ]
-
-                    component "core/Voltage Measurement" Va {
-                        execution_rate = "inherit"
-                        sig_output = "True"
-                    }
-                    [
-                        position = 7800, 9616
-                        size = 64, 32
-                    ]
-
-                    component gen_limiter Limit2 {
-                    }
-                    [
-                        position = 7848, 8568
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch20" {
-                        criterion = "ctrl >= threshold"
-                    }
-                    [
-                        position = 8032, 8552
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain2 {
-                        gain = "1000"
-                    }
-                    [
-                        position = 7648, 8536
-                        hide_name = True
-                    ]
-
-                    component gen_comparator Comparator1 {
-                    }
-                    [
-                        position = 8000, 8400
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant2 {
-                        execution_rate = "Ts"
-                        value = "CPL_curr/(VLL*kVLL)"
-                    }
-                    [
-                        position = 7600, 8464
-                        hide_name = True
-                    ]
-
-                    component gen_product Product4 {
-                    }
-                    [
-                        position = 7688, 8488
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_gain Gain16 {
-                        gain = "-1"
-                    }
-                    [
-                        position = 8056, 8328
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit10 {
-                        upper_limit = "0"
-                    }
-                    [
-                        position = 7976, 8328
-                        hide_name = True
-                    ]
-
-                    component gen_sign Sign1 {
-                    }
-                    [
-                        position = 8120, 8328
-                        hide_name = True
-                    ]
-
-                    component gen_product Product19 {
-                        signs = "3"
-                    }
-                    [
-                        position = 8408, 8080
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit11 {
-                        lower_limit = "0"
-                    }
-                    [
-                        position = 7544, 8096
-                        hide_name = True
-                    ]
-
-                    component gen_sign Sign2 {
-                    }
-                    [
-                        position = 7608, 8096
-                        hide_name = True
-                    ]
-
-                    component gen_product Product14 {
-                        signs = "*/"
-                    }
-                    [
-                        position = 7824, 8248
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain15 {
-                        gain = "1000"
-                    }
-                    [
-                        position = 7720, 8240
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit7 {
-                        lower_limit = "0"
-                    }
-                    [
-                        position = 7896, 8248
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch23" {
-                        criterion = "ctrl >= threshold"
-                    }
-                    [
-                        position = 8104, 8232
-                        hide_name = True
-                    ]
-
-                    component gen_comparator Comparator4 {
-                    }
-                    [
-                        position = 8040, 8160
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_product Product15 {
-                    }
-                    [
-                        position = 7824, 8152
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant8 {
-                        execution_rate = "inherit"
-                        value = "CPL_curr/(VLL*kVLL)"
-                    }
-                    [
-                        position = 7728, 8176
-                        hide_name = True
-                    ]
-
-                    component gen_z_domain_transfer "Discrete Transfer Function4" {
-                        a_coeff = "[0.01,1]"
-                        b_coeff = "[1]"
-                        domain = "S-domain"
-                        method = "Euler"
-                    }
-                    [
-                        position = 8168, 8232
-                        hide_name = True
-                    ]
-
-                    component gen_product Product17 {
-                        signs = "3"
-                    }
-                    [
-                        position = 8392, 8328
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum5 {
-                        signs = "+++"
-                    }
-                    [
-                        position = 8600, 8624
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_abs Abs1 {
-                    }
-                    [
-                        position = 7544, 8144
-                        hide_name = True
-                    ]
-
-                    component gen_product Product20 {
-                    }
-                    [
-                        position = 6696, 8112
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain18 {
-                        gain = "Pc_pQ"
-                    }
-                    [
-                        position = 6808, 8112
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum8 {
-                        signs = "+++-"
-                    }
-                    [
-                        position = 7192, 8392
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_sign Sign3 {
-                    }
-                    [
-                        position = 6664, 8056
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch24" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 6920, 8128
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain19 {
-                        gain = "Pc_nQ"
-                    }
-                    [
-                        position = 6808, 8144
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain20 {
-                        gain = "1/(1000*Rsnb)"
-                    }
-                    [
-                        position = 7200, 7968
-                        hide_name = True
-                    ]
-
-                    component gen_product Product21 {
-                    }
-                    [
-                        position = 6944, 7784
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_gain Gain21 {
-                        gain = "nQc_P"
-                    }
-                    [
-                        position = 7040, 7784
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum9 {
-                        signs = "+++++"
-                    }
-                    [
-                        position = 7328, 8016
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit12 {
-                        lower_limit = "0"
-                    }
-                    [
-                        position = 6840, 7832
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch25" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 7200, 7800
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_gain Gain22 {
-                        gain = "pQc_P"
-                    }
-                    [
-                        position = 7040, 7816
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant14 {
-                        execution_rate = "Ts"
-                        value = "Pc_T_pQ"
-                    }
-                    [
-                        position = 6696, 8232
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch26" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 6808, 8256
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant15 {
-                        execution_rate = "Ts"
-                        value = "Pc_T_nQ"
-                    }
-                    [
-                        position = 6696, 8272
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant17 {
-                        execution_rate = "Ts"
-                        value = "pQc_T"
-                    }
-                    [
-                        position = 6752, 7912
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch27" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 6840, 7936
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant18 {
-                        execution_rate = "Ts"
-                        value = "nQc_T"
-                    }
-                    [
-                        position = 6752, 7952
-                        hide_name = True
-                    ]
-
-                    component gen_abs Abs2 {
-                    }
-                    [
-                        position = 7912, 8392
-                        hide_name = True
-                    ]
-
-                    component gen_abs Abs3 {
-                    }
-                    [
-                        position = 7952, 8448
-                        rotation = left
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum14 {
-                        signs = "+-"
-                    }
-                    [
-                        position = 6248, 7832
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant19 {
-                        execution_rate = "Ts"
-                        value = "60"
-                    }
-                    [
-                        position = 6152, 7872
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum15 {
-                        signs = "+-"
-                    }
-                    [
-                        position = 6400, 7776
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant20 {
-                        execution_rate = "Ts"
-                    }
-                    [
-                        position = 6320, 7768
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain24 {
-                        gain = "Fc"
-                    }
-                    [
-                        position = 6320, 7832
-                        hide_name = True
-                    ]
-
-                    component "core/Edge Detection" "Edge Detection1" {
-                    }
-                    [
-                        position = 9048, 8744
-                        rotation = right
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component "core/Rate Transition" "Rate Transition1" {
-                        execution_rate = "Tfst"
-                    }
-                    [
-                        position = 8680, 8696
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component gen_c_function "C function1" {
-                        global_variables = "real counter;real m0;real m1;real m2;real corr;"
-                        init_fnc = "/*Begin code section*/
-counter=0;
-/*End code section*/"
-                        input_terminals = "real sync;real z;real zi;real zii;real Ts;real Ts_fast;"
-                        input_terminals_dimensions = "inherit;inherit;inherit;inherit;inherit;inherit"
-                        input_terminals_feedthrough = "True;True;True;True;True;True"
-                        input_terminals_show_labels = "True;True;True;True;True;True"
-                        output_fnc = "/*Begin code section*/
-counter = counter + Ts_fast;
-if (sync > 0 ) {
-    out = z;
-    counter = 0;
-
-}
-else {
-    corr = 1 - 0.11 * (Ts - Ts_fast)/Ts;
-    m2 = (zi - zii)/Ts;
-    m1 = (z - zi)/Ts;
-    m0 = m1 + (m1-m2);
-
-    out = z + counter * corr * m0;
-}
-
-if (counter >= Ts) {
-    counter = 0;
-}
-/*End code section*/"
-                        output_terminals_dimensions = "inherit"
-                        output_terminals_feedthrough = "True"
-                        output_terminals_show_labels = "True"
-                    }
-                    [
-                        position = 8976, 8952
-                        rotation = right
-                        hide_name = True
-                        size = 48, 128
-                    ]
-
-                    component tm_delay "Unit Delay9" {
-                    }
-                    [
-                        position = 8680, 8760
-                        hide_name = True
-                    ]
-
-                    component tm_delay "Unit Delay10" {
-                    }
-                    [
-                        position = 8784, 8816
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant21 {
-                        execution_rate = "Tfst"
-                        value = "Ts"
-                    }
-                    [
-                        position = 8912, 8864
-                        hide_name = True
-                    ]
-
-                    component "core/Rate Transition" "Rate Transition2" {
-                        execution_rate = "Tfst"
-                    }
-                    [
-                        position = 8784, 8760
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component "core/Rate Transition" "Rate Transition3" {
-                        execution_rate = "Tfst"
-                    }
-                    [
-                        position = 8864, 8816
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component sys_signal_switch "Signal switch28" {
-                        threshold = "Tfst"
-                    }
-                    [
-                        position = 9128, 9064
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component src_constant Constant22 {
-                        execution_rate = "Tfst"
-                        value = "Ts"
-                    }
-                    [
-                        position = 9080, 9120
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch29" {
-                    }
-                    [
-                        position = 9224, 9024
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component src_constant Constant23 {
-                        execution_rate = "Tfst"
-                        value = "Tfast_en"
-                    }
-                    [
-                        position = 9168, 9112
-                        hide_name = True
-                    ]
-
-                    component gen_product Product22 {
-                    }
-                    [
-                        position = 6952, 7928
-                        hide_name = True
-                    ]
-
-                    component gen_product Product23 {
-                    }
-                    [
-                        position = 6920, 8264
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant24 {
-                        execution_rate = "Ts"
-                        value = "pQc_Q"
-                    }
-                    [
-                        position = 6944, 7680
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant25 {
-                        execution_rate = "Ts"
-                        value = "nQc_Q"
-                    }
-                    [
-                        position = 6944, 7632
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch30" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 7016, 7664
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_product Product24 {
-                    }
-                    [
-                        position = 7168, 7672
-                        hide_name = True
-                    ]
-
-                    component gen_terminator Termination70 {
-                    }
-                    [
-                        position = 7616, 8640
-                        rotation = left
-                        hide_name = True
-                    ]
-
-                    component gen_terminator Termination71 {
-                    }
-                    [
-                        position = 7648, 8680
-                        rotation = left
-                        hide_name = True
-                    ]
-
-                    component gen_terminator Termination72 {
-                    }
-                    [
-                        position = 7624, 8824
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain26 {
-                        gain = "1/(1000*Rsnb)"
-                    }
-                    [
-                        position = 7104, 8344
-                        hide_name = True
-                    ]
-
-                    component "core/Single phase PLL" "Single phase PLL1" {
-                        k_SOGI = "0.6"
-                        kd_PLL_HIGH = "0"
-                        kd_PLL_LOW = "0"
-                        kp_PLL_HIGH = "65.7"
-                        kp_PLL_LOW = "5.81e2"
-                        offset_Hz = "Freq"
-                    }
-                    [
-                        position = 7560, 8736
-                        hide_name = True
-                        size = 64, 98
-                    ]
-
-                    component gen_trigonometric "Trigonometric function1" {
-                    }
-                    [
-                        position = 7856, 8640
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain25 {
-                        gain = "1.41421356"
-                    }
-                    [
-                        position = 8024, 8680
-                        hide_name = True
-                    ]
-
-                    component gen_product Product25 {
-                    }
-                    [
-                        position = 8136, 8648
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component pas_capacitor C1 {
-                        capacitance = "1/(Rsnb*2*np.pi*Freq)"
-                    }
-                    [
-                        position = 7808, 9400
-                    ]
-
-                    component gen_trigonometric "Trigonometric function2" {
-                    }
-                    [
-                        position = 8024, 8760
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum16 {
-                        signs = "++"
-                    }
-                    [
-                        position = 7944, 8760
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant26 {
-                        execution_rate = "Ts"
-                        value = "-np.pi/2"
-                    }
-                    [
-                        position = 7848, 8776
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant28 {
-                        execution_rate = "Tfst"
-                        value = "Tfst"
-                    }
-                    [
-                        position = 8872, 8888
-                        hide_name = True
-                    ]
-
-                    component gen_product Product26 {
-                        signs = "**"
-                    }
-                    [
-                        position = 8240, 8768
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum17 {
-                        signs = "++"
-                    }
-                    [
-                        position = 7944, 8848
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant27 {
-                        execution_rate = "Ts"
-                        value = "np.pi/2"
-                    }
-                    [
-                        position = 7832, 8872
-                        hide_name = True
-                    ]
-
-                    component gen_trigonometric "Trigonometric function3" {
-                    }
-                    [
-                        position = 8024, 8848
-                        hide_name = True
-                    ]
-
-                    component gen_product Product27 {
-                        signs = "**"
-                    }
-                    [
-                        position = 8136, 8840
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    port P2 {
-                        position = right:2
-                        kind = pe
-                    }
-                    [
-                        position = 8000, 9200
-                        rotation = down
-                    ]
-
-                    port P3 {
-                        position = left:1
-                        kind = pe
-                    }
-                    [
-                        position = 7584, 9200
-                    ]
-
-                    port P {
-                        position = top:1
-                        kind = sp
-                        direction =  out
-                        sp_type {
-                            default = auto
-                            readonly = True
-                        }
-                    }
-                    [
-                        position = 6120, 8008
-                    ]
-
-                    port Q {
-                        position = top:2
-                        kind = sp
-                        direction =  out
-                        sp_type {
-                            default = auto
-                            readonly = True
-                        }
-                    }
-                    [
-                        position = 6120, 8080
-                    ]
-
-                    tag Goto1 {
-                        value = "ws"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 7720, 8736
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From1 {
-                        value = "ws"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6152, 7824
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag Goto2 {
-                        value = "kP"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 6200, 8008
-                        size = 0, 0
-                    ]
-
-                    tag Goto3 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 6200, 8080
-                        size = 0, 0
-                    ]
-
-                    tag From2 {
-                        value = "kP"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7120, 8304
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From3 {
-                        value = "kP"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6752, 7832
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From4 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7264, 7856
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From5 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6544, 8056
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From6 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6832, 8312
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From7 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7080, 7680
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag Goto4 {
-                        value = "Va"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 7744, 9568
-                        rotation = down
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From8 {
-                        value = "Va"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7448, 8736
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From9 {
-                        value = "Va_rms"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7936, 8680
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From10 {
-                        value = "Va_rms"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7208, 8584
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag Goto5 {
-                        value = "Va_rms"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 7744, 9464
-                        rotation = down
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag Goto6 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 7512, 8592
-                        hide_name = True
-                        size = 100, 20
-                    ]
-
-                    tag From11 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7648, 8592
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag From12 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7080, 7968
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag From13 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6992, 8344
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag From14 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7704, 8272
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag Goto7 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 6744, 8056
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From15 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7144, 7856
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From16 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6952, 7728
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From17 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6784, 7864
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From18 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6760, 8184
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From19 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6864, 8080
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag Goto8 {
-                        value = "Ia_load"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 9360, 9024
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From20 {
-                        value = "Ia_load"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7728, 9160
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    junction Junction1 sp
-                    [
-                        position = 7328, 8584
-                    ]
-
-                    junction Junction10 sp
-                    [
-                        position = 7880, 8568
-                    ]
-
-                    junction Junction11 sp
-                    [
-                        position = 7952, 8488
-                    ]
-
-                    junction Junction62 sp
-                    [
-                        position = 7328, 8144
-                    ]
-
-                    junction Junction50 sp
-                    [
-                        position = 7976, 8248
-                    ]
-
-                    junction Junction51 sp
-                    [
-                        position = 7944, 8152
-                    ]
-
-                    junction Junction74 sp
-                    [
-                        position = 7688, 8144
-                    ]
-
-                    junction Junction78 sp
-                    [
-                        position = 6760, 8112
-                    ]
-
-                    junction Junction82 sp
-                    [
-                        position = 7328, 8096
-                    ]
-
-                    junction Junction84 sp
-                    [
-                        position = 6992, 7784
-                    ]
-
-                    junction Junction92 sp
-                    [
-                        position = 7592, 8536
-                    ]
-
-                    junction Junction95 sp
-                    [
-                        position = 6488, 7776
-                    ]
-
-                    junction Junction96 sp
-                    [
-                        position = 6616, 8056
-                    ]
-
-                    junction Junction101 sp
-                    [
-                        position = 9000, 8696
-                    ]
-
-                    junction Junction102 sp
-                    [
-                        position = 8600, 8696
-                    ]
-
-                    junction Junction109 sp
-                    [
-                        position = 8744, 8760
-                    ]
-
-                    junction Junction112 sp
-                    [
-                        position = 6888, 7832
-                    ]
-
-                    junction Junction130 pe
-                    [
-                        position = 7688, 9304
-                    ]
-
-                    junction Junction131 pe
-                    [
-                        position = 7912, 9304
-                    ]
-
-                    junction Junction133 sp
-                    [
-                        position = 8208, 8232
-                    ]
-
-                    junction Junction121 sp
-                    [
-                        position = 8080, 8680
-                    ]
-
-                    junction Junction127 sp
-                    [
-                        position = 8080, 8776
-                    ]
-
-                    junction Junction129 sp
-                    [
-                        position = 7792, 8752
-                    ]
-
-                    junction Junction137 pe
-                    [
-                        position = 7912, 9400
-                    ]
-
-                    junction Junction138 pe
-                    [
-                        position = 7688, 9400
-                    ]
-
-                    junction Junction139 pe
-                    [
-                        position = 7912, 9504
-                    ]
-
-                    junction Junction140 pe
-                    [
-                        position = 7688, 9504
-                    ]
-
-                    junction Junction141 sp
-                    [
-                        position = 7792, 8752
-                    ]
-
-                    junction Junction142 sp
-                    [
-                        position = 9080, 9008
-                    ]
-
-                    junction Junction143 sp
-                    [
-                        position = 9048, 8696
-                    ]
-
-                    junction Junction144 pe
-                    [
-                        position = 7912, 9200
-                    ]
-
-                    junction Junction145 pe
-                    [
-                        position = 7688, 9200
-                    ]
-
-                    connect Limit1.out Junction1 as Connection9
-                    connect Junction1 Product2.in1 as Connection10
-                    connect "Discrete Transfer Function1.out" Product3.in1 as Connection16
-                    connect Product1.out Limit2.in as Connection44
-                    connect Gain2.out Product1.in as Connection47
-                    connect Constant2.out Product4.in1 as Connection54
-                    connect Comparator1.out "Signal switch20.in2" as Connection57
-                    connect Junction10 Limit2.out as Connection59
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Signal switch20.in1" Junction10 as Connection60
-                    connect Product4.out Junction11 as Connection62
-                    connect "Signal switch20.in" Junction11 as Connection64
-                    connect Limit10.out Gain16.in as Connection299
-                    connect Gain16.out Sign1.in as Connection315
-                    connect Limit10.in Junction62 as Connection319
-                    [
-                        position = 0, 0
-                    ]
-                    connect Limit11.out Sign2.in as Connection320
-                    connect Gain15.out Product14.in as Connection227
-                    connect Product14.out Limit7.in as Connection228
-                    connect Comparator4.out "Signal switch23.in2" as Connection229
-                    connect Limit7.out Junction50 as Connection233
-                    connect Junction50 "Signal switch23.in1" as Connection234
-                    connect Comparator4.in1 Junction50 as Connection235
-                    connect "Signal switch23.in" Junction51 as Connection236
-                    connect Product15.out Junction51 as Connection238
-                    connect Constant8.out Product15.in1 as Connection239
-                    connect "Signal switch23.out" "Discrete Transfer Function4.in" as Connection243
-                    connect Junction51 Comparator4.in2 as Connection253
-                    [
-                        position = 0, 0
-                    ]
-                    connect Abs1.in Junction62 as Connection395
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product15.in Junction74 as Connection396
-                    connect Junction74 Abs1.out as Connection397
-                    connect Gain15.in Junction74 as Connection398
-                    connect "Signal switch24.in" Gain18.out as Connection419
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Signal switch24.out" Sum8.in as Connection420
-                    connect Gain19.out "Signal switch24.in1" as Connection422
-                    connect Product20.out Junction78 as Connection423
-                    connect Junction78 Gain18.in as Connection424
-                    connect Gain19.in Junction78 as Connection425
-                    connect Product19.in2 Sign2.out as Connection430
-                    [
-                        position = 0, 0
-                    ]
-                    connect Limit11.in Junction82 as Connection444
-                    connect Junction82 Junction62 as Connection445
-                    [
-                        position = 0, 0
-                    ]
-                    connect Sum9.out Junction82 as Connection446
-                    connect Product21.out Junction84 as Connection461
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction84 Gain21.in as Connection462
-                    connect Gain22.in Junction84 as Connection463
-                    connect Gain22.out "Signal switch25.in" as Connection464
-                    connect Gain21.out "Signal switch25.in1" as Connection468
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction92 Gain2.in as Connection509
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product4.in Junction92 as Connection510
-                    connect Comparator1.in1 Abs2.out as Connection511
-                    connect Abs2.in Junction10 as Connection512
-                    connect Junction11 Abs3.in as Connection513
-                    connect Abs3.out Comparator1.in2 as Connection514
-                    connect Junction92 Sum8.out as Connection515
-                    [
-                        position = 0, 0
-                    ]
-                    connect From1 Sum14.in as Connection523
-                    connect Constant19.out Sum14.in1 as Connection524
-                    connect Constant20.out Sum15.in as Connection525
-                    connect Gain24.in Sum14.out as Connection526
-                    connect Gain24.out Sum15.in1 as Connection527
-                    connect Sum15.out Junction95 as Connection529
-                    connect P Goto2 as Connection532
-                    connect Q Goto3 as Connection533
-                    connect From3 Limit12.in as Connection535
-                    connect Sign3.in Junction96 as Connection538
-                    connect Junction96 Product20.in as Connection539
-                    [
-                        position = 0, 0
-                    ]
-                    connect From5 Junction96 as Connection540
-                    connect "Signal switch20.out" "Discrete Transfer Function1.in" as Connection554
-                    connect Constant21.out "C function1.Ts" as Connection605
-                    connect Junction101 "C function1.z" as Connection607
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Rate Transition3.in" "Unit Delay10.out" as Connection615
-                    connect "Rate Transition2.out" "C function1.zi" as Connection616
-                    connect "Rate Transition3.out" "C function1.zii" as Connection617
-                    connect "C function1.sync" "Edge Detection1.Out1" as Connection618
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Rate Transition1.in" Junction102 as Connection622
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant22.out "Signal switch28.in2" as Connection624
-                    connect Sum5.out Junction102 as Connection649
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant23.out "Signal switch29.in2" as Connection653
-                    connect "Signal switch28.out" "Signal switch29.in" as Connection660
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction102 "Unit Delay9.in" as Connection683
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Rate Transition2.in" Junction109 as Connection684
-                    connect Junction109 "Unit Delay9.out" as Connection685
-                    connect "Unit Delay10.in" Junction109 as Connection686
-                    connect Junction95 Product21.in1 as Connection697
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Signal switch27.out" Product22.in1 as Connection701
-                    connect Product21.in Junction112 as Connection704
-                    connect Junction112 Limit12.out as Connection705
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product22.in Junction112 as Connection706
-                    connect Product23.in "Signal switch26.out" as Connection710
-                    connect From6 Product23.in1 as Connection711
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant24.out "Signal switch30.in" as Connection713
-                    connect Constant25.out "Signal switch30.in1" as Connection714
-                    connect "Single phase PLL1.f" Goto1 as Connection881
-                    connect "Signal switch30.out" Product24.in as Connection718
-                    connect From7 Product24.in1 as Connection719
-                    connect "Single phase PLL1.d" Termination70.in as Connection882
-                    connect "Single phase PLL1.q" Termination71.in as Connection883
-                    connect Product20.in1 Junction95 as Connection721
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Single phase PLL1.sin(wt)" Termination72.in as Connection884
-                    connect "Signal switch28.in" "C function1.out" as Connection724
-                    [
-                        position = 0, 0
-                    ]
-                    connect Gain20.out Sum9.in4 as Connection869
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant17.out "Signal switch27.in" as Connection875
-                    connect Constant18.out "Signal switch27.in1" as Connection876
-                    connect Constant14.out "Signal switch26.in" as Connection878
-                    connect Constant15.out "Signal switch26.in1" as Connection879
-                    connect Product3.in Product25.out as Connection767
-                    connect Constant26.out Sum16.in1 as Connection771
-                    connect Sum16.out "Trigonometric function2.in" as Connection772
-                    connect "Trigonometric function1.out" Product25.in1 as Connection773
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant28.out "C function1.Ts_fast" as Connection837
-                    connect R1.p_node Junction130 as Connection838
-                    connect R1.n_node Junction131 as Connection843
-                    connect Product25.in Junction121 as Connection786
-                    connect "Discrete Transfer Function4.out" Junction133 as Connection847
-                    connect Junction121 Gain25.out as Connection787
-                    connect Product17.in Junction133 as Connection849
-                    connect "Trigonometric function2.out" Product26.in as Connection793
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product19.in1 Junction133 as Connection860
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant27.out Sum17.in1 as Connection800
-                    connect Junction1 Product2.in as Connection866
-                    [
-                        position = 0, 0
-                    ]
-                    connect Sum17.out "Trigonometric function3.in" as Connection808
-                    connect "Trigonometric function3.out" Product27.in as Connection809
-                    connect Product26.in1 Junction127 as Connection813
-                    connect Junction127 Junction121 as Connection814
-                    connect Product27.in1 Junction127 as Connection815
-                    connect Product19.in Product26.out as Connection818
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Trigonometric function1.in" Junction129 as Connection823
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Single phase PLL1.wt" Junction129 as Connection825
-                    connect Product22.out Sum9.in3 as Connection889
-                    connect From4 Sum9.in2 as Connection890
-                    connect "Signal switch25.out" Sum9.in1 as Connection891
-                    connect Product24.out Sum9.in as Connection892
-                    connect Gain26.out Sum8.in3 as Connection894
-                    connect C1.n_node Junction137 as Connection896
-                    connect Junction137 Junction131 as Connection897
-                    connect C1.p_node Junction138 as Connection900
-                    connect Junction138 Junction130 as Connection901
-                    connect Varms.n_node Junction139 as Connection904
-                    connect Junction139 Junction137 as Connection905
-                    connect Va.n_node Junction139 as Connection906
-                    connect Varms.p_node Junction140 as Connection908
-                    connect Junction140 Junction138 as Connection909
-                    connect Va.p_node Junction140 as Connection910
-                    connect Goto4 Va.out as Connection914
-                    connect From8 "Single phase PLL1.In" as Connection915
-                    connect From9 Gain25.in as Connection917
-                    connect Limit1.in From10 as Connection918
-                    connect Goto5 Varms.out as Connection919
-                    connect Sum16.in Junction141 as Connection921
-                    [
-                        position = 0, 0
-                        breakpoints = 7816, 8752
-                    ]
-                    connect Junction141 Junction129 as Connection922
-                    connect Sum17.in Junction141 as Connection923
-                    connect Sign1.out Product17.in1 as Connection925
-                    connect Product27.out Product17.in2 as Connection926
-                    connect From11 Product1.in1 as Connection931
-                    connect From12 Gain20.in as Connection933
-                    connect From13 Gain26.in as Connection935
-                    connect Goto6 Product2.out as Connection936
-                    connect From14 Product14.in1 as Connection937
-                    connect From15 "Signal switch25.in2" as Connection942
-                    connect From16 "Signal switch30.in2" as Connection944
-                    connect From17 "Signal switch27.in2" as Connection946
-                    connect Goto7 Sign3.out as Connection947
-                    connect From18 "Signal switch26.in2" as Connection948
-                    connect From19 "Signal switch24.in2" as Connection949
-                    connect Product23.out Sum8.in1 as Connection950
-                    connect From2 Sum8.in2 as Connection951
-                    connect Product3.out Sum5.in2 as Connection952
-                    connect Product17.out Sum5.in1 as Connection953
-                    connect Product19.out Sum5.in as Connection954
-                    connect Junction101 "Rate Transition1.out" as Connection956
-                    connect "Signal switch28.in1" Junction142 as Connection957
-                    connect Junction142 "Signal switch29.in1" as Connection958
-                    connect Junction101 Junction143 as Connection959
-                    connect Junction143 "Edge Detection1.In1" as Connection960
-                    connect Junction142 Junction143 as Connection961
-                    connect Goto8 "Signal switch29.out" as Connection965
-                    connect From20 Isp1.in as Connection966
-                    connect Junction131 Junction144 as Connection969
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction144 Isp1.p_node as Connection970
-                    [
-                        position = 0, 0
-                    ]
-                    connect P2 Junction144 as Connection971
-                    connect Junction130 Junction145 as Connection972
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction145 Isp1.n_node as Connection973
-                    [
-                        position = 0, 0
-                    ]
-                    connect P3 Junction145 as Connection974
+                component "OpenDSS/single-phase CPL" CPLB {
                 }
                 [
-                    position = 7936, 8096
+                    position = 7928, 8088
                     size = 48, 48
                 ]
 
-                component Subsystem CPL3 {
-                    layout = dynamic
-                    component gen_limiter Limit1 {
-                        lower_limit = "0.1"
-                    }
-                    [
-                        position = 7576, 8520
-                        hide_name = True
-                    ]
-
-                    component gen_product Product1 {
-                        signs = "*/"
-                    }
-                    [
-                        position = 8040, 8504
-                        hide_name = True
-                    ]
-
-                    component gen_product Product2 {
-                    }
-                    [
-                        position = 7656, 8528
-                        hide_name = True
-                    ]
-
-                    component gen_product Product3 {
-                    }
-                    [
-                        position = 8504, 8496
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_z_domain_transfer "Discrete Transfer Function1" {
-                        a_coeff = "[0.01,1]"
-                        b_coeff = "[1]"
-                        domain = "S-domain"
-                        method = "Euler"
-                    }
-                    [
-                        position = 8408, 8488
-                        hide_name = True
-                    ]
-
-                    component pas_resistor R1 {
-                        resistance = "Rsnb"
-                    }
-                    [
-                        position = 8088, 9240
-                    ]
-
-                    component "core/Signal Controlled Current Source" Isp1 {
-                    }
-                    [
-                        position = 8080, 9136
-                        scale = -1, 1
-                        size = 64, 32
-                    ]
-
-                    component "core/Voltage RMS" Varms {
-                        sig_output = "True"
-                    }
-                    [
-                        position = 8080, 9440
-                        size = 64, 32
-                    ]
-
-                    component "core/Voltage Measurement" Va {
-                        execution_rate = "inherit"
-                        sig_output = "True"
-                    }
-                    [
-                        position = 8080, 9552
-                        size = 64, 32
-                    ]
-
-                    component gen_limiter Limit2 {
-                    }
-                    [
-                        position = 8128, 8504
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch20" {
-                        criterion = "ctrl >= threshold"
-                    }
-                    [
-                        position = 8312, 8488
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain2 {
-                        gain = "1000"
-                    }
-                    [
-                        position = 7928, 8472
-                        hide_name = True
-                    ]
-
-                    component gen_comparator Comparator1 {
-                    }
-                    [
-                        position = 8280, 8336
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant2 {
-                        execution_rate = "Ts"
-                        value = "CPL_curr/(VLL*kVLL)"
-                    }
-                    [
-                        position = 7880, 8400
-                        hide_name = True
-                    ]
-
-                    component gen_product Product4 {
-                    }
-                    [
-                        position = 7968, 8424
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_gain Gain16 {
-                        gain = "-1"
-                    }
-                    [
-                        position = 8336, 8264
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit10 {
-                        upper_limit = "0"
-                    }
-                    [
-                        position = 8256, 8264
-                        hide_name = True
-                    ]
-
-                    component gen_sign Sign1 {
-                    }
-                    [
-                        position = 8400, 8264
-                        hide_name = True
-                    ]
-
-                    component gen_product Product19 {
-                        signs = "3"
-                    }
-                    [
-                        position = 8688, 8016
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit11 {
-                        lower_limit = "0"
-                    }
-                    [
-                        position = 7824, 8032
-                        hide_name = True
-                    ]
-
-                    component gen_sign Sign2 {
-                    }
-                    [
-                        position = 7888, 8032
-                        hide_name = True
-                    ]
-
-                    component gen_product Product14 {
-                        signs = "*/"
-                    }
-                    [
-                        position = 8104, 8184
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain15 {
-                        gain = "1000"
-                    }
-                    [
-                        position = 8000, 8176
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit7 {
-                        lower_limit = "0"
-                    }
-                    [
-                        position = 8176, 8184
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch23" {
-                        criterion = "ctrl >= threshold"
-                    }
-                    [
-                        position = 8384, 8168
-                        hide_name = True
-                    ]
-
-                    component gen_comparator Comparator4 {
-                    }
-                    [
-                        position = 8320, 8096
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_product Product15 {
-                    }
-                    [
-                        position = 8104, 8088
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant8 {
-                        execution_rate = "inherit"
-                        value = "CPL_curr/(VLL*kVLL)"
-                    }
-                    [
-                        position = 8008, 8112
-                        hide_name = True
-                    ]
-
-                    component gen_z_domain_transfer "Discrete Transfer Function4" {
-                        a_coeff = "[0.01,1]"
-                        b_coeff = "[1]"
-                        domain = "S-domain"
-                        method = "Euler"
-                    }
-                    [
-                        position = 8448, 8168
-                        hide_name = True
-                    ]
-
-                    component gen_product Product17 {
-                        signs = "3"
-                    }
-                    [
-                        position = 8672, 8264
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum5 {
-                        signs = "+++"
-                    }
-                    [
-                        position = 8880, 8560
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_abs Abs1 {
-                    }
-                    [
-                        position = 7824, 8080
-                        hide_name = True
-                    ]
-
-                    component gen_product Product20 {
-                    }
-                    [
-                        position = 6976, 8048
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain18 {
-                        gain = "Pc_pQ"
-                    }
-                    [
-                        position = 7088, 8048
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum8 {
-                        signs = "+++-"
-                    }
-                    [
-                        position = 7472, 8328
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_sign Sign3 {
-                    }
-                    [
-                        position = 6944, 7992
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch24" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 7200, 8064
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain19 {
-                        gain = "Pc_nQ"
-                    }
-                    [
-                        position = 7088, 8080
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain20 {
-                        gain = "1/(1000*Rsnb)"
-                    }
-                    [
-                        position = 7480, 7904
-                        hide_name = True
-                    ]
-
-                    component gen_product Product21 {
-                    }
-                    [
-                        position = 7224, 7720
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_gain Gain21 {
-                        gain = "nQc_P"
-                    }
-                    [
-                        position = 7320, 7720
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum9 {
-                        signs = "+++++"
-                    }
-                    [
-                        position = 7608, 7952
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_limiter Limit12 {
-                        lower_limit = "0"
-                    }
-                    [
-                        position = 7120, 7768
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch25" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 7480, 7736
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_gain Gain22 {
-                        gain = "pQc_P"
-                    }
-                    [
-                        position = 7320, 7752
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant14 {
-                        execution_rate = "Ts"
-                        value = "Pc_T_pQ"
-                    }
-                    [
-                        position = 6976, 8168
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch26" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 7088, 8192
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant15 {
-                        execution_rate = "Ts"
-                        value = "Pc_T_nQ"
-                    }
-                    [
-                        position = 6976, 8208
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant17 {
-                        execution_rate = "Ts"
-                        value = "pQc_T"
-                    }
-                    [
-                        position = 7032, 7848
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch27" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 7120, 7872
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant18 {
-                        execution_rate = "Ts"
-                        value = "nQc_T"
-                    }
-                    [
-                        position = 7032, 7888
-                        hide_name = True
-                    ]
-
-                    component gen_abs Abs2 {
-                    }
-                    [
-                        position = 8192, 8328
-                        hide_name = True
-                    ]
-
-                    component gen_abs Abs3 {
-                    }
-                    [
-                        position = 8232, 8384
-                        rotation = left
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum14 {
-                        signs = "+-"
-                    }
-                    [
-                        position = 6528, 7768
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant19 {
-                        execution_rate = "Ts"
-                        value = "60"
-                    }
-                    [
-                        position = 6432, 7808
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum15 {
-                        signs = "+-"
-                    }
-                    [
-                        position = 6680, 7712
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant20 {
-                        execution_rate = "Ts"
-                    }
-                    [
-                        position = 6600, 7704
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain24 {
-                        gain = "Fc"
-                    }
-                    [
-                        position = 6600, 7768
-                        hide_name = True
-                    ]
-
-                    component "core/Edge Detection" "Edge Detection1" {
-                    }
-                    [
-                        position = 9328, 8680
-                        rotation = right
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component "core/Rate Transition" "Rate Transition1" {
-                        execution_rate = "Tfst"
-                    }
-                    [
-                        position = 8960, 8632
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component gen_c_function "C function1" {
-                        global_variables = "real counter;real m0;real m1;real m2;real corr;"
-                        init_fnc = "/*Begin code section*/
-counter=0;
-/*End code section*/"
-                        input_terminals = "real sync;real z;real zi;real zii;real Ts;real Ts_fast;"
-                        input_terminals_dimensions = "inherit;inherit;inherit;inherit;inherit;inherit"
-                        input_terminals_feedthrough = "True;True;True;True;True;True"
-                        input_terminals_show_labels = "True;True;True;True;True;True"
-                        output_fnc = "/*Begin code section*/
-counter = counter + Ts_fast;
-if (sync > 0 ) {
-    out = z;
-    counter = 0;
-
-}
-else {
-    corr = 1 - 0.11 * (Ts - Ts_fast)/Ts;
-    m2 = (zi - zii)/Ts;
-    m1 = (z - zi)/Ts;
-    m0 = m1 + (m1-m2);
-
-    out = z + counter * corr * m0;
-}
-
-if (counter >= Ts) {
-    counter = 0;
-}
-/*End code section*/"
-                        output_terminals_dimensions = "inherit"
-                        output_terminals_feedthrough = "True"
-                        output_terminals_show_labels = "True"
-                    }
-                    [
-                        position = 9256, 8888
-                        rotation = right
-                        hide_name = True
-                        size = 48, 128
-                    ]
-
-                    component tm_delay "Unit Delay9" {
-                    }
-                    [
-                        position = 8960, 8696
-                        hide_name = True
-                    ]
-
-                    component tm_delay "Unit Delay10" {
-                    }
-                    [
-                        position = 9064, 8752
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant21 {
-                        execution_rate = "Tfst"
-                        value = "Ts"
-                    }
-                    [
-                        position = 9192, 8800
-                        hide_name = True
-                    ]
-
-                    component "core/Rate Transition" "Rate Transition2" {
-                        execution_rate = "Tfst"
-                    }
-                    [
-                        position = 9064, 8696
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component "core/Rate Transition" "Rate Transition3" {
-                        execution_rate = "Tfst"
-                    }
-                    [
-                        position = 9144, 8752
-                        hide_name = True
-                        size = 32, 32
-                    ]
-
-                    component sys_signal_switch "Signal switch28" {
-                        threshold = "Tfst"
-                    }
-                    [
-                        position = 9408, 9000
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component src_constant Constant22 {
-                        execution_rate = "Tfst"
-                        value = "Ts"
-                    }
-                    [
-                        position = 9360, 9056
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch29" {
-                    }
-                    [
-                        position = 9504, 8960
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component src_constant Constant23 {
-                        execution_rate = "Tfst"
-                        value = "Tfast_en"
-                    }
-                    [
-                        position = 9448, 9048
-                        hide_name = True
-                    ]
-
-                    component gen_product Product22 {
-                    }
-                    [
-                        position = 7232, 7864
-                        hide_name = True
-                    ]
-
-                    component gen_product Product23 {
-                    }
-                    [
-                        position = 7200, 8200
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant24 {
-                        execution_rate = "Ts"
-                        value = "pQc_Q"
-                    }
-                    [
-                        position = 7224, 7616
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant25 {
-                        execution_rate = "Ts"
-                        value = "nQc_Q"
-                    }
-                    [
-                        position = 7224, 7568
-                        hide_name = True
-                    ]
-
-                    component sys_signal_switch "Signal switch30" {
-                        criterion = "ctrl >= threshold"
-                        threshold = "0"
-                    }
-                    [
-                        position = 7296, 7600
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component gen_product Product24 {
-                    }
-                    [
-                        position = 7448, 7608
-                        hide_name = True
-                    ]
-
-                    component gen_terminator Termination70 {
-                    }
-                    [
-                        position = 7896, 8576
-                        rotation = left
-                        hide_name = True
-                    ]
-
-                    component gen_terminator Termination71 {
-                    }
-                    [
-                        position = 7928, 8616
-                        rotation = left
-                        hide_name = True
-                    ]
-
-                    component gen_terminator Termination72 {
-                    }
-                    [
-                        position = 7904, 8760
-                        rotation = right
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain26 {
-                        gain = "1/(1000*Rsnb)"
-                    }
-                    [
-                        position = 7384, 8280
-                        hide_name = True
-                    ]
-
-                    component "core/Single phase PLL" "Single phase PLL1" {
-                        k_SOGI = "0.6"
-                        kd_PLL_HIGH = "0"
-                        kd_PLL_LOW = "0"
-                        kp_PLL_HIGH = "65.7"
-                        kp_PLL_LOW = "5.81e2"
-                        offset_Hz = "Freq"
-                    }
-                    [
-                        position = 7840, 8672
-                        hide_name = True
-                        size = 64, 98
-                    ]
-
-                    component gen_trigonometric "Trigonometric function1" {
-                    }
-                    [
-                        position = 8136, 8576
-                        hide_name = True
-                    ]
-
-                    component gen_gain Gain25 {
-                        gain = "1.41421356"
-                    }
-                    [
-                        position = 8304, 8616
-                        hide_name = True
-                    ]
-
-                    component gen_product Product25 {
-                    }
-                    [
-                        position = 8416, 8584
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    component pas_capacitor C1 {
-                        capacitance = "1/(Rsnb*2*np.pi*Freq)"
-                    }
-                    [
-                        position = 8088, 9336
-                    ]
-
-                    component gen_trigonometric "Trigonometric function2" {
-                    }
-                    [
-                        position = 8304, 8696
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum16 {
-                        signs = "++"
-                    }
-                    [
-                        position = 8224, 8696
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant26 {
-                        execution_rate = "Ts"
-                        value = "-np.pi/2"
-                    }
-                    [
-                        position = 8128, 8712
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant28 {
-                        execution_rate = "Tfst"
-                        value = "Tfst"
-                    }
-                    [
-                        position = 9152, 8824
-                        hide_name = True
-                    ]
-
-                    component gen_product Product26 {
-                        signs = "**"
-                    }
-                    [
-                        position = 8520, 8704
-                        hide_name = True
-                    ]
-
-                    component gen_sum Sum17 {
-                        signs = "++"
-                    }
-                    [
-                        position = 8224, 8784
-                        hide_name = True
-                    ]
-
-                    component src_constant Constant27 {
-                        execution_rate = "Ts"
-                        value = "np.pi/2"
-                    }
-                    [
-                        position = 8112, 8808
-                        hide_name = True
-                    ]
-
-                    component gen_trigonometric "Trigonometric function3" {
-                    }
-                    [
-                        position = 8304, 8784
-                        hide_name = True
-                    ]
-
-                    component gen_product Product27 {
-                        signs = "**"
-                    }
-                    [
-                        position = 8416, 8776
-                        hide_name = True
-                        scale = 1, -1
-                    ]
-
-                    port P2 {
-                        position = right:2
-                        kind = pe
-                    }
-                    [
-                        position = 8256, 9136
-                        rotation = down
-                    ]
-
-                    port P3 {
-                        position = left:1
-                        kind = pe
-                    }
-                    [
-                        position = 7888, 9136
-                    ]
-
-                    port P {
-                        position = top:1
-                        kind = sp
-                        direction =  out
-                        sp_type {
-                            default = auto
-                            readonly = True
-                        }
-                    }
-                    [
-                        position = 6400, 7944
-                    ]
-
-                    port Q {
-                        position = top:2
-                        kind = sp
-                        direction =  out
-                        sp_type {
-                            default = auto
-                            readonly = True
-                        }
-                    }
-                    [
-                        position = 6400, 8016
-                    ]
-
-                    tag Goto1 {
-                        value = "ws"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 8000, 8672
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From1 {
-                        value = "ws"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6432, 7760
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag Goto2 {
-                        value = "kP"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 6480, 7944
-                        size = 0, 0
-                    ]
-
-                    tag Goto3 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 6480, 8016
-                        size = 0, 0
-                    ]
-
-                    tag From2 {
-                        value = "kP"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7400, 8240
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From3 {
-                        value = "kP"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7032, 7768
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From4 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7544, 7792
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From5 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 6824, 7992
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From6 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7112, 8248
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From7 {
-                        value = "kQ"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7360, 7616
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag Goto4 {
-                        value = "Va"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 8024, 9504
-                        rotation = down
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From8 {
-                        value = "Va"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7728, 8672
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From9 {
-                        value = "Va_rms"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 8216, 8616
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From10 {
-                        value = "Va_rms"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7488, 8520
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag Goto5 {
-                        value = "Va_rms"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 8024, 9400
-                        rotation = down
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag Goto6 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 7792, 8528
-                        hide_name = True
-                        size = 100, 20
-                    ]
-
-                    tag From11 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7928, 8528
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag From12 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7360, 7904
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag From13 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7272, 8280
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag From14 {
-                        value = "Va_rms_squared"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7984, 8208
-                        hide_name = True
-                        size = 97, 20
-                    ]
-
-                    tag Goto7 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 7024, 7992
-                        hide_name = True
-                        size = 60, 20
-                    ]
-
-                    tag From15 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7424, 7792
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From16 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7232, 7664
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From17 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7064, 7800
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From18 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7040, 8120
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag From19 {
-                        value = "Q_sign"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 7144, 8016
-                        hide_name = True
-                        size = 57, 20
-                    ]
-
-                    tag Goto8 {
-                        value = "Ia_load"
-                        scope = local
-                        kind = sp
-                        direction = in
-                    }
-                    [
-                        position = 9640, 8960
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    tag From20 {
-                        value = "Ia_load"
-                        scope = local
-                        kind = sp
-                        direction = out
-                    }
-                    [
-                        position = 8008, 9096
-                        hide_name = True
-                        size = 0, 0
-                    ]
-
-                    junction Junction1 sp
-                    [
-                        position = 7608, 8520
-                    ]
-
-                    junction Junction10 sp
-                    [
-                        position = 8160, 8504
-                    ]
-
-                    junction Junction11 sp
-                    [
-                        position = 8232, 8424
-                    ]
-
-                    junction Junction62 sp
-                    [
-                        position = 7608, 8080
-                    ]
-
-                    junction Junction50 sp
-                    [
-                        position = 8256, 8184
-                    ]
-
-                    junction Junction51 sp
-                    [
-                        position = 8224, 8088
-                    ]
-
-                    junction Junction74 sp
-                    [
-                        position = 7968, 8080
-                    ]
-
-                    junction Junction78 sp
-                    [
-                        position = 7040, 8048
-                    ]
-
-                    junction Junction82 sp
-                    [
-                        position = 7608, 8032
-                    ]
-
-                    junction Junction84 sp
-                    [
-                        position = 7272, 7720
-                    ]
-
-                    junction Junction92 sp
-                    [
-                        position = 7872, 8472
-                    ]
-
-                    junction Junction95 sp
-                    [
-                        position = 6768, 7712
-                    ]
-
-                    junction Junction96 sp
-                    [
-                        position = 6896, 7992
-                    ]
-
-                    junction Junction101 sp
-                    [
-                        position = 9280, 8632
-                    ]
-
-                    junction Junction102 sp
-                    [
-                        position = 8880, 8632
-                    ]
-
-                    junction Junction109 sp
-                    [
-                        position = 9024, 8696
-                    ]
-
-                    junction Junction112 sp
-                    [
-                        position = 7168, 7768
-                    ]
-
-                    junction Junction130 pe
-                    [
-                        position = 7968, 9240
-                    ]
-
-                    junction Junction131 pe
-                    [
-                        position = 8192, 9240
-                    ]
-
-                    junction Junction133 sp
-                    [
-                        position = 8488, 8168
-                    ]
-
-                    junction Junction121 sp
-                    [
-                        position = 8360, 8616
-                    ]
-
-                    junction Junction127 sp
-                    [
-                        position = 8360, 8712
-                    ]
-
-                    junction Junction129 sp
-                    [
-                        position = 8072, 8688
-                    ]
-
-                    junction Junction137 pe
-                    [
-                        position = 8192, 9336
-                    ]
-
-                    junction Junction138 pe
-                    [
-                        position = 7968, 9336
-                    ]
-
-                    junction Junction139 pe
-                    [
-                        position = 8192, 9440
-                    ]
-
-                    junction Junction140 pe
-                    [
-                        position = 7968, 9440
-                    ]
-
-                    junction Junction141 sp
-                    [
-                        position = 8072, 8688
-                    ]
-
-                    junction Junction142 sp
-                    [
-                        position = 9360, 8944
-                    ]
-
-                    junction Junction143 sp
-                    [
-                        position = 9328, 8632
-                    ]
-
-                    junction Junction144 pe
-                    [
-                        position = 8192, 9136
-                    ]
-
-                    junction Junction145 pe
-                    [
-                        position = 7968, 9136
-                    ]
-
-                    connect Limit1.out Junction1 as Connection9
-                    connect Junction1 Product2.in1 as Connection10
-                    connect "Discrete Transfer Function1.out" Product3.in1 as Connection16
-                    connect Product1.out Limit2.in as Connection44
-                    connect Gain2.out Product1.in as Connection47
-                    connect Constant2.out Product4.in1 as Connection54
-                    connect Comparator1.out "Signal switch20.in2" as Connection57
-                    connect Junction10 Limit2.out as Connection59
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Signal switch20.in1" Junction10 as Connection60
-                    connect Product4.out Junction11 as Connection62
-                    connect "Signal switch20.in" Junction11 as Connection64
-                    connect Limit10.out Gain16.in as Connection299
-                    connect Gain16.out Sign1.in as Connection315
-                    connect Limit10.in Junction62 as Connection319
-                    [
-                        position = 0, 0
-                    ]
-                    connect Limit11.out Sign2.in as Connection320
-                    connect Gain15.out Product14.in as Connection227
-                    connect Product14.out Limit7.in as Connection228
-                    connect Comparator4.out "Signal switch23.in2" as Connection229
-                    connect Limit7.out Junction50 as Connection233
-                    connect Junction50 "Signal switch23.in1" as Connection234
-                    connect Comparator4.in1 Junction50 as Connection235
-                    connect "Signal switch23.in" Junction51 as Connection236
-                    connect Product15.out Junction51 as Connection238
-                    connect Constant8.out Product15.in1 as Connection239
-                    connect "Signal switch23.out" "Discrete Transfer Function4.in" as Connection243
-                    connect Junction51 Comparator4.in2 as Connection253
-                    [
-                        position = 0, 0
-                    ]
-                    connect Abs1.in Junction62 as Connection395
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product15.in Junction74 as Connection396
-                    connect Junction74 Abs1.out as Connection397
-                    connect Gain15.in Junction74 as Connection398
-                    connect "Signal switch24.in" Gain18.out as Connection419
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Signal switch24.out" Sum8.in as Connection420
-                    connect Gain19.out "Signal switch24.in1" as Connection422
-                    connect Product20.out Junction78 as Connection423
-                    connect Junction78 Gain18.in as Connection424
-                    connect Gain19.in Junction78 as Connection425
-                    connect Product19.in2 Sign2.out as Connection430
-                    [
-                        position = 0, 0
-                    ]
-                    connect Limit11.in Junction82 as Connection444
-                    connect Junction82 Junction62 as Connection445
-                    [
-                        position = 0, 0
-                    ]
-                    connect Sum9.out Junction82 as Connection446
-                    connect Product21.out Junction84 as Connection461
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction84 Gain21.in as Connection462
-                    connect Gain22.in Junction84 as Connection463
-                    connect Gain22.out "Signal switch25.in" as Connection464
-                    connect Gain21.out "Signal switch25.in1" as Connection468
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction92 Gain2.in as Connection509
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product4.in Junction92 as Connection510
-                    connect Comparator1.in1 Abs2.out as Connection511
-                    connect Abs2.in Junction10 as Connection512
-                    connect Junction11 Abs3.in as Connection513
-                    connect Abs3.out Comparator1.in2 as Connection514
-                    connect Junction92 Sum8.out as Connection515
-                    [
-                        position = 0, 0
-                    ]
-                    connect From1 Sum14.in as Connection523
-                    connect Constant19.out Sum14.in1 as Connection524
-                    connect Constant20.out Sum15.in as Connection525
-                    connect Gain24.in Sum14.out as Connection526
-                    connect Gain24.out Sum15.in1 as Connection527
-                    connect Sum15.out Junction95 as Connection529
-                    connect P Goto2 as Connection532
-                    connect Q Goto3 as Connection533
-                    connect From3 Limit12.in as Connection535
-                    connect Sign3.in Junction96 as Connection538
-                    connect Junction96 Product20.in as Connection539
-                    [
-                        position = 0, 0
-                    ]
-                    connect From5 Junction96 as Connection540
-                    connect "Signal switch20.out" "Discrete Transfer Function1.in" as Connection554
-                    connect Constant21.out "C function1.Ts" as Connection605
-                    connect Junction101 "C function1.z" as Connection607
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Rate Transition3.in" "Unit Delay10.out" as Connection615
-                    connect "Rate Transition2.out" "C function1.zi" as Connection616
-                    connect "Rate Transition3.out" "C function1.zii" as Connection617
-                    connect "C function1.sync" "Edge Detection1.Out1" as Connection618
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Rate Transition1.in" Junction102 as Connection622
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant22.out "Signal switch28.in2" as Connection624
-                    connect Sum5.out Junction102 as Connection649
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant23.out "Signal switch29.in2" as Connection653
-                    connect "Signal switch28.out" "Signal switch29.in" as Connection660
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction102 "Unit Delay9.in" as Connection683
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Rate Transition2.in" Junction109 as Connection684
-                    connect Junction109 "Unit Delay9.out" as Connection685
-                    connect "Unit Delay10.in" Junction109 as Connection686
-                    connect Junction95 Product21.in1 as Connection697
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Signal switch27.out" Product22.in1 as Connection701
-                    connect Product21.in Junction112 as Connection704
-                    connect Junction112 Limit12.out as Connection705
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product22.in Junction112 as Connection706
-                    connect Product23.in "Signal switch26.out" as Connection710
-                    connect From6 Product23.in1 as Connection711
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant24.out "Signal switch30.in" as Connection713
-                    connect Constant25.out "Signal switch30.in1" as Connection714
-                    connect "Single phase PLL1.f" Goto1 as Connection881
-                    connect "Signal switch30.out" Product24.in as Connection718
-                    connect From7 Product24.in1 as Connection719
-                    connect "Single phase PLL1.d" Termination70.in as Connection882
-                    connect "Single phase PLL1.q" Termination71.in as Connection883
-                    connect Product20.in1 Junction95 as Connection721
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Single phase PLL1.sin(wt)" Termination72.in as Connection884
-                    connect "Signal switch28.in" "C function1.out" as Connection724
-                    [
-                        position = 0, 0
-                    ]
-                    connect Gain20.out Sum9.in4 as Connection869
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant17.out "Signal switch27.in" as Connection875
-                    connect Constant18.out "Signal switch27.in1" as Connection876
-                    connect Constant14.out "Signal switch26.in" as Connection878
-                    connect Constant15.out "Signal switch26.in1" as Connection879
-                    connect Product3.in Product25.out as Connection767
-                    connect Constant26.out Sum16.in1 as Connection771
-                    connect Sum16.out "Trigonometric function2.in" as Connection772
-                    connect "Trigonometric function1.out" Product25.in1 as Connection773
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant28.out "C function1.Ts_fast" as Connection837
-                    connect R1.p_node Junction130 as Connection838
-                    connect R1.n_node Junction131 as Connection843
-                    connect Product25.in Junction121 as Connection786
-                    connect "Discrete Transfer Function4.out" Junction133 as Connection847
-                    connect Junction121 Gain25.out as Connection787
-                    connect Product17.in Junction133 as Connection849
-                    connect "Trigonometric function2.out" Product26.in as Connection793
-                    [
-                        position = 0, 0
-                    ]
-                    connect Product19.in1 Junction133 as Connection860
-                    [
-                        position = 0, 0
-                    ]
-                    connect Constant27.out Sum17.in1 as Connection800
-                    connect Junction1 Product2.in as Connection866
-                    [
-                        position = 0, 0
-                    ]
-                    connect Sum17.out "Trigonometric function3.in" as Connection808
-                    connect "Trigonometric function3.out" Product27.in as Connection809
-                    connect Product26.in1 Junction127 as Connection813
-                    connect Junction127 Junction121 as Connection814
-                    connect Product27.in1 Junction127 as Connection815
-                    connect Product19.in Product26.out as Connection818
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Trigonometric function1.in" Junction129 as Connection823
-                    [
-                        position = 0, 0
-                    ]
-                    connect "Single phase PLL1.wt" Junction129 as Connection825
-                    connect Product22.out Sum9.in3 as Connection889
-                    connect From4 Sum9.in2 as Connection890
-                    connect "Signal switch25.out" Sum9.in1 as Connection891
-                    connect Product24.out Sum9.in as Connection892
-                    connect Gain26.out Sum8.in3 as Connection894
-                    connect C1.n_node Junction137 as Connection896
-                    connect Junction137 Junction131 as Connection897
-                    connect C1.p_node Junction138 as Connection900
-                    connect Junction138 Junction130 as Connection901
-                    connect Varms.n_node Junction139 as Connection904
-                    connect Junction139 Junction137 as Connection905
-                    connect Va.n_node Junction139 as Connection906
-                    connect Varms.p_node Junction140 as Connection908
-                    connect Junction140 Junction138 as Connection909
-                    connect Va.p_node Junction140 as Connection910
-                    connect Goto4 Va.out as Connection914
-                    connect From8 "Single phase PLL1.In" as Connection915
-                    connect From9 Gain25.in as Connection917
-                    connect Limit1.in From10 as Connection918
-                    connect Goto5 Varms.out as Connection919
-                    connect Sum16.in Junction141 as Connection921
-                    [
-                        position = 0, 0
-                        breakpoints = 8096, 8688
-                    ]
-                    connect Junction141 Junction129 as Connection922
-                    connect Sum17.in Junction141 as Connection923
-                    connect Sign1.out Product17.in1 as Connection925
-                    connect Product27.out Product17.in2 as Connection926
-                    connect From11 Product1.in1 as Connection931
-                    connect From12 Gain20.in as Connection933
-                    connect From13 Gain26.in as Connection935
-                    connect Goto6 Product2.out as Connection936
-                    connect From14 Product14.in1 as Connection937
-                    connect From15 "Signal switch25.in2" as Connection942
-                    connect From16 "Signal switch30.in2" as Connection944
-                    connect From17 "Signal switch27.in2" as Connection946
-                    connect Goto7 Sign3.out as Connection947
-                    connect From18 "Signal switch26.in2" as Connection948
-                    connect From19 "Signal switch24.in2" as Connection949
-                    connect Product23.out Sum8.in1 as Connection950
-                    connect From2 Sum8.in2 as Connection951
-                    connect Product3.out Sum5.in2 as Connection952
-                    connect Product17.out Sum5.in1 as Connection953
-                    connect Product19.out Sum5.in as Connection954
-                    connect Junction101 "Rate Transition1.out" as Connection956
-                    connect "Signal switch28.in1" Junction142 as Connection957
-                    connect Junction142 "Signal switch29.in1" as Connection958
-                    connect Junction101 Junction143 as Connection959
-                    connect Junction143 "Edge Detection1.In1" as Connection960
-                    connect Junction142 Junction143 as Connection961
-                    connect Goto8 "Signal switch29.out" as Connection965
-                    connect From20 Isp1.in as Connection966
-                    connect Junction131 Junction144 as Connection969
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction144 Isp1.p_node as Connection970
-                    [
-                        position = 0, 0
-                    ]
-                    connect P2 Junction144 as Connection971
-                    connect Junction130 Junction145 as Connection972
-                    [
-                        position = 0, 0
-                    ]
-                    connect Junction145 Isp1.n_node as Connection973
-                    [
-                        position = 0, 0
-                    ]
-                    connect P3 Junction145 as Connection974
+                component "OpenDSS/single-phase CPL" CPLC {
                 }
                 [
-                    position = 7832, 8176
+                    position = 7824, 8168
                     size = 48, 48
                 ]
 
@@ -26080,7 +21199,7 @@ if (counter >= Ts) {
                     kind = pe
                 }
                 [
-                    position = 7664, 8024
+                    position = 7656, 8008
                 ]
 
                 port N {
@@ -26089,7 +21208,7 @@ if (counter >= Ts) {
                     kind = pe
                 }
                 [
-                    position = 8320, 8096
+                    position = 8320, 8088
                     rotation = down
                 ]
 
@@ -26099,7 +21218,7 @@ if (counter >= Ts) {
                     direction =  in
                 }
                 [
-                    position = 7664, 8096
+                    position = 7656, 8088
                 ]
 
                 port C1 {
@@ -26108,7 +21227,7 @@ if (counter >= Ts) {
                     direction =  in
                 }
                 [
-                    position = 7664, 8176
+                    position = 7656, 8168
                 ]
 
                 tag Goto1 {
@@ -26224,32 +21343,27 @@ if (counter >= Ts) {
 
                 junction Junction11 pe
                 [
-                    position = 8264, 8096
-                ]
-
-                junction Junction12 pe
-                [
-                    position = 8264, 8096
+                    position = 8248, 8088
                 ]
 
                 junction Junction13 sp
                 [
-                    position = 7928, 7904
+                    position = 7920, 7904
                 ]
 
                 junction Junction14 sp
                 [
-                    position = 7944, 7944
+                    position = 7936, 7944
                 ]
 
                 junction Junction15 sp
                 [
-                    position = 7824, 7904
+                    position = 7816, 7904
                 ]
 
                 junction Junction16 sp
                 [
-                    position = 7840, 7944
+                    position = 7832, 7944
                 ]
 
                 connect Constant1.out Goto3 as Connection341
@@ -26284,27 +21398,26 @@ if (counter >= Ts) {
                     position = 0, 0
                 ]
                 connect Sum14.out Goto2 as Connection1118
-                connect A1 CPL1.P3 as Connection1119
-                connect CPL1.P2 Junction11 as Connection1151
                 connect Junction11 N as Connection1152
                 [
                     position = 0, 0
                 ]
-                connect Junction12 Junction11 as Connection1155
-                connect CPL1.P Junction13 as Connection1159
-                connect CPL1.Q Junction14 as Connection1162
                 connect Junction13 Junction15 as Connection1165
                 connect Junction15 From3 as Connection1166
                 connect Junction14 Junction16 as Connection1168
                 connect Junction16 From4 as Connection1169
-                connect CPL2.P3 B1 as ConnB
-                connect CPL3.P3 C1 as ConnC
-                connect CPL2.Q Junction14 as Connection1164
-                connect CPL2.P Junction13 as Connection1161
-                connect CPL3.Q Junction16 as Connection1170
-                connect CPL3.P Junction15 as Connection1167
-                connect CPL2.P2 Junction12 as Connection1154
-                connect CPL3.P2 Junction12 as Connection1156
+                connect A1 CPLA.P3 as Connection1170
+                connect CPLA.P2 Junction11 as Connection1171
+                connect CPLA.P Junction13 as Connection1172
+                connect CPLA.Q Junction14 as Connection1173
+                connect B1 CPLB.P3 as Connection1174
+                connect CPLB.P2 Junction11 as Connection1175
+                connect CPLB.P Junction13 as Connection1176
+                connect CPLB.Q Junction14 as Connection1177
+                connect C1 CPLC.P3 as Connection1178
+                connect CPLC.P2 Junction11 as Connection1179
+                connect CPLC.P Junction15 as Connection1180
+                connect CPLC.Q Junction16 as Connection1181
                 connect Gain1.in From1 as connP
                 connect Gain2.in From2 as connQ
 
@@ -26506,6 +21619,15 @@ if (counter >= Ts) {
                         default_value = "True"
                         group = "Execution rate"
                         no_evaluate
+
+                        CODE property_value_changed
+                            comp_handle = mdl.get_sub_level_handle(container_handle)
+
+                            for phase in ["A", "B", "C"]:
+                                CPL_phase = mdl.get_item(f"CPL{phase}", parent=comp_handle, item_type="component")
+                                if CPL_phase:
+                                    mdl.set_property_value(mdl.prop(CPL_phase, "Fast_con"), new_value)
+                        ENDCODE
                     }
 
                     Tfst {
@@ -26623,84 +21745,64 @@ if (counter >= Ts) {
                             comp_handle = mdl.get_sub_level_handle(container_handle)
 
                             if new_value == "3":
-                                pA = mdl.get_item("A1", parent=comp_handle, item_type=ITEM_PORT)
-                                pB = mdl.get_item("B1", parent=comp_handle, item_type=ITEM_PORT)
-                                pC = mdl.get_item("C1", parent=comp_handle, item_type=ITEM_PORT)
-                                CPLA = mdl.get_item("CPL1", parent=comp_handle, item_type=ITEM_COMPONENT)
-                                CPLB = mdl.get_item("CPL2", parent=comp_handle, item_type=ITEM_COMPONENT)
-                                CPLC = mdl.get_item("CPL3", parent=comp_handle, item_type=ITEM_COMPONENT)
-                                mdl.enable_items(CPLB)
-                                mdl.enable_items(CPLC)
-                                if not pB:
-                                    pB = mdl.create_port(parent=comp_handle, name="B1", direction="out", kind = "pe",
-                                                        terminal_position=("left", 2),
-                                                        position=(7662, 8094), rotation="up")
-                                    mdl.create_connection(mdl.term(CPLB, "P3"), pB, name="ConnB")
-                                if not pC:
-                                    pC = mdl.create_port(parent=comp_handle, name="C1", direction="out", kind = "pe",
-                                                        terminal_position=("left", 3),
-                                                        position=(7662, 8175), rotation="up")
-                                    mdl.create_connection(mdl.term(CPLC, "P3"), pC, name="ConnC")
+                                for phase in ["A", "B", "C"]:
+                                    if phase == "B":
+                                        port_offset = (0, 80)
+                                        cpl_offset = (-104, 80)
+                                    elif phase == "C":
+                                        port_offset = (0, 160)
+                                        cpl_offset = (-208, 160)
+                                    else:
+                                        port_offset = (0, 0)
+                                        cpl_offset = (0, 0)
 
-                                jun14 = mdl.get_item("Junction14", parent=comp_handle, item_type="junction")
-                                conn1164 = mdl.get_item("Connection1164", parent=comp_handle, item_type="connection")
-                                if not conn1164:
-                                    mdl.create_connection(mdl.term(CPLB, "Q"), jun14, name="Connection1164")
-                                jun13 = mdl.get_item("Junction13", parent=comp_handle, item_type="junction")
-                                conn1161 = mdl.get_item("Connection1161", parent=comp_handle, item_type="connection")
-                                if not conn1161:
-                                    mdl.create_connection(mdl.term(CPLB, "P"), jun13, name="Connection1161")
-                                jun16 = mdl.get_item("Junction16", parent=comp_handle, item_type="junction")
-                                conn1170 = mdl.get_item("Connection1170", parent=comp_handle, item_type="connection")
-                                if not conn1170:
-                                    mdl.create_connection(mdl.term(CPLC, "Q"), jun16, name="Connection1170")
-                                jun15 = mdl.get_item("Junction15", parent=comp_handle, item_type="junction")
-                                conn1167 = mdl.get_item("Connection1167", parent=comp_handle, item_type="connection")
-                                if not conn1167:
-                                    mdl.create_connection(mdl.term(CPLC, "P"), jun15, name="Connection1167")
+                                    port_phase = mdl.get_item(f"{phase}1", parent=comp_handle, item_type=ITEM_PORT)
+                                    if not port_phase:
+                                        port_phase = mdl.create_port(parent=comp_handle,
+                                                                     name=f"{phase}1", direction="out",
+                                                                     kind = "pe",
+                                                                     terminal_position=("left", 2),
+                                                                     position=(7656 + port_offset[0], 8008 + port_offset[1]),
+                                                                     rotation="up")
 
-                                jun12 = mdl.get_item("Junction12", parent=comp_handle, item_type="junction")
-                                conn1154 = mdl.get_item("Connection1154", parent=comp_handle, item_type="connection")
-                                if not conn1154:
-                                    mdl.create_connection(mdl.term(CPLB, "P2"), jun12, name="Connection1154")
-                                conn1156 = mdl.get_item("Connection1156", parent=comp_handle, item_type="connection")
-                                if not conn1156:
-                                    mdl.create_connection(mdl.term(CPLC, "P2"), jun12, name="Connection1156")
+                                    CPL_phase = mdl.get_item(f"CPL{phase}", parent=comp_handle, item_type=ITEM_COMPONENT)
+                                    if not CPL_phase:
+                                        CPL_phase = mdl.create_component("OpenDSS/single-phase CPL",
+                                                                         name=f"CPL{phase}",
+                                                                         parent=comp_handle,
+                                                                         position=(8032 + cpl_offset[0], 8008 + cpl_offset[1]))
+
+                                    if len(mdl.find_connections(port_phase)) == 0:
+                                        mdl.create_connection(port_phase, mdl.term(CPL_phase, "P3"))
+
+                                    jun11 = mdl.get_item("Junction11", parent=comp_handle, item_type="junction")
+
+                                    if len(mdl.find_connections(mdl.term(CPL_phase, "P2"))) == 0:
+                                        mdl.create_connection(mdl.term(CPL_phase, "P2"), jun11)
+
+                                    if phase in ["A", "B"]:
+                                        jun_p = mdl.get_item("Junction13", parent=comp_handle, item_type="junction")
+                                        jun_q = mdl.get_item("Junction14", parent=comp_handle, item_type="junction")
+                                    else:
+                                        jun_p = mdl.get_item("Junction15", parent=comp_handle, item_type="junction")
+                                        jun_q = mdl.get_item("Junction16", parent=comp_handle, item_type="junction")
+
+                                    if len(mdl.find_connections(mdl.term(CPL_phase, "P"))) == 0:
+                                        mdl.create_connection(mdl.term(CPL_phase, "P"), jun_p)
+
+                                    if len(mdl.find_connections(mdl.term(CPL_phase, "Q"))) == 0:
+                                        mdl.create_connection(mdl.term(CPL_phase, "Q"), jun_q)
+
 
                             if new_value == "1":
-                                pA = mdl.get_item("A1", parent=comp_handle, item_type=ITEM_PORT)
-                                pB = mdl.get_item("B1", parent=comp_handle, item_type=ITEM_PORT)
-                                pC = mdl.get_item("C1", parent=comp_handle, item_type=ITEM_PORT)
-                                CPLA = mdl.get_item("CPL1", parent=comp_handle, item_type=ITEM_COMPONENT)
-                                CPLB = mdl.get_item("CPL2", parent=comp_handle, item_type=ITEM_COMPONENT)
-                                CPLC = mdl.get_item("CPL3", parent=comp_handle, item_type=ITEM_COMPONENT)
+                                for phase in ["B", "C"]:
+                                    port_phase = mdl.get_item(f"{phase}1", parent=comp_handle, item_type=ITEM_PORT)
+                                    if port_phase:
+                                        mdl.delete_item(port_phase)
 
-                                if pB:
-                                    mdl.delete_item(pB)
-                                if pC:
-                                    mdl.delete_item(pC)
-
-                                conn1164 = mdl.get_item("Connection1164", parent=comp_handle, item_type="connection")
-                                if conn1164:
-                                    mdl.delete_item(conn1164)
-                                conn1161 = mdl.get_item("Connection1161", parent=comp_handle, item_type="connection")
-                                if conn1161:
-                                    mdl.delete_item(conn1161)
-                                conn1170 = mdl.get_item("Connection1170", parent=comp_handle, item_type="connection")
-                                if conn1170:
-                                    mdl.delete_item(conn1170)
-                                conn1167 = mdl.get_item("Connection1167", parent=comp_handle, item_type="connection")
-                                if conn1167:
-                                    mdl.delete_item(conn1167)
-                                conn1154 = mdl.get_item("Connection1154", parent=comp_handle, item_type="connection")
-                                if conn1154:
-                                    mdl.delete_item(conn1154)
-                                conn1156 = mdl.get_item("Connection1156", parent=comp_handle, item_type="connection")
-                                if conn1156:
-                                    mdl.delete_item(conn1156)
-
-                                mdl.disable_items(CPLB)
-                                mdl.disable_items(CPLC)
+                                    CPL_phase = mdl.get_item(f"CPL{phase}", parent=comp_handle, item_type=ITEM_COMPONENT)
+                                    if CPL_phase:
+                                        mdl.delete_item(CPL_phase)
                         ENDCODE
                     }
 
@@ -31570,6 +26672,2008 @@ if (counter >= Ts) {
                 position = 9016, 8144
                 size = 168, 232
             ]
+
+            component Subsystem "single-phase CPL" {
+                layout = dynamic
+                component "core/Limit" Limit1 {
+                    lower_limit = "0.1"
+                }
+                [
+                    position = 7464, 8168
+                    hide_name = True
+                ]
+
+                component "core/Product" Product1 {
+                    signs = "*/"
+                }
+                [
+                    position = 7928, 8152
+                    hide_name = True
+                ]
+
+                component "core/Product" Product2 {
+                }
+                [
+                    position = 7544, 8176
+                    hide_name = True
+                ]
+
+                component "core/Product" Product3 {
+                }
+                [
+                    position = 8392, 8144
+                    hide_name = True
+                    scale = 1, -1
+                ]
+
+                component "core/Discrete Transfer Function" "Discrete Transfer Function1" {
+                    a_coeff = "[0.01,1]"
+                    b_coeff = "[1]"
+                    domain = "S-domain"
+                    method = "Euler"
+                }
+                [
+                    position = 8296, 8136
+                    hide_name = True
+                ]
+
+                component "core/Resistor" R1 {
+                    resistance = "Rsnb"
+                }
+                [
+                    position = 7976, 8888
+                ]
+
+                component "core/Signal Controlled Current Source" Isp1 {
+                }
+                [
+                    position = 7968, 8784
+                    scale = -1, 1
+                    size = 64, 32
+                ]
+
+                component "core/Voltage RMS" Varms {
+                    sig_output = "True"
+                }
+                [
+                    position = 7968, 9088
+                    size = 64, 32
+                ]
+
+                component "core/Voltage Measurement" Va {
+                    execution_rate = "inherit"
+                    sig_output = "True"
+                }
+                [
+                    position = 7968, 9200
+                    size = 64, 32
+                ]
+
+                component "core/Limit" Limit2 {
+                }
+                [
+                    position = 8016, 8152
+                    hide_name = True
+                ]
+
+                component "core/Signal switch" "Signal switch20" {
+                    criterion = "ctrl >= threshold"
+                    threshold = "0"
+                }
+                [
+                    position = 8200, 8136
+                    hide_name = True
+                ]
+
+                component "core/Gain" Gain2 {
+                    gain = "1000"
+                }
+                [
+                    position = 7816, 8120
+                    hide_name = True
+                ]
+
+                component "core/Comparator" Comparator1 {
+                }
+                [
+                    position = 8168, 7984
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant2 {
+                    execution_rate = "Ts"
+                    value = "CPL_curr/(VLL*kVLL)"
+                }
+                [
+                    position = 7768, 8048
+                    hide_name = True
+                ]
+
+                component "core/Product" Product4 {
+                }
+                [
+                    position = 7856, 8072
+                    hide_name = True
+                    scale = 1, -1
+                ]
+
+                component "core/Gain" Gain16 {
+                    gain = "-1"
+                }
+                [
+                    position = 8224, 7912
+                    hide_name = True
+                ]
+
+                component "core/Limit" Limit10 {
+                    upper_limit = "0"
+                }
+                [
+                    position = 8144, 7912
+                    hide_name = True
+                ]
+
+                component "core/Sign" Sign1 {
+                }
+                [
+                    position = 8288, 7912
+                    hide_name = True
+                ]
+
+                component "core/Product" Product19 {
+                    signs = "3"
+                }
+                [
+                    position = 8576, 7664
+                    hide_name = True
+                ]
+
+                component "core/Limit" Limit11 {
+                    lower_limit = "0"
+                }
+                [
+                    position = 7712, 7680
+                    hide_name = True
+                ]
+
+                component "core/Sign" Sign2 {
+                }
+                [
+                    position = 7776, 7680
+                    hide_name = True
+                ]
+
+                component "core/Product" Product14 {
+                    signs = "*/"
+                }
+                [
+                    position = 7992, 7832
+                    hide_name = True
+                ]
+
+                component "core/Gain" Gain15 {
+                    gain = "1000"
+                }
+                [
+                    position = 7888, 7824
+                    hide_name = True
+                ]
+
+                component "core/Limit" Limit7 {
+                    lower_limit = "0"
+                }
+                [
+                    position = 8064, 7832
+                    hide_name = True
+                ]
+
+                component "core/Signal switch" "Signal switch23" {
+                    criterion = "ctrl >= threshold"
+                    threshold = "0"
+                }
+                [
+                    position = 8272, 7816
+                    hide_name = True
+                ]
+
+                component "core/Comparator" Comparator4 {
+                }
+                [
+                    position = 8208, 7744
+                    hide_name = True
+                    scale = 1, -1
+                ]
+
+                component "core/Product" Product15 {
+                }
+                [
+                    position = 7992, 7736
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant8 {
+                    execution_rate = "inherit"
+                    value = "CPL_curr/(VLL*kVLL)"
+                }
+                [
+                    position = 7896, 7760
+                    hide_name = True
+                ]
+
+                component "core/Discrete Transfer Function" "Discrete Transfer Function4" {
+                    a_coeff = "[0.01,1]"
+                    b_coeff = "[1]"
+                    domain = "S-domain"
+                    method = "Euler"
+                }
+                [
+                    position = 8336, 7816
+                    hide_name = True
+                ]
+
+                component "core/Product" Product17 {
+                    signs = "3"
+                }
+                [
+                    position = 8560, 7912
+                    hide_name = True
+                ]
+
+                component "core/Sum" Sum5 {
+                    signs = "+++"
+                }
+                [
+                    position = 8768, 8208
+                    rotation = right
+                    hide_name = True
+                ]
+
+                component "core/Abs" Abs1 {
+                }
+                [
+                    position = 7712, 7728
+                    hide_name = True
+                ]
+
+                component "core/Product" Product20 {
+                }
+                [
+                    position = 6864, 7696
+                    hide_name = True
+                ]
+
+                component "core/Gain" Gain18 {
+                    gain = "Pc_pQ"
+                }
+                [
+                    position = 6976, 7696
+                    hide_name = True
+                ]
+
+                component "core/Sum" Sum8 {
+                    signs = "+++-"
+                }
+                [
+                    position = 7360, 7976
+                    rotation = right
+                    hide_name = True
+                ]
+
+                component "core/Sign" Sign3 {
+                }
+                [
+                    position = 6832, 7640
+                    hide_name = True
+                ]
+
+                component "core/Signal switch" "Signal switch24" {
+                    criterion = "ctrl >= threshold"
+                    threshold = "0"
+                }
+                [
+                    position = 7088, 7712
+                    hide_name = True
+                ]
+
+                component "core/Gain" Gain19 {
+                    gain = "Pc_nQ"
+                }
+                [
+                    position = 6976, 7728
+                    hide_name = True
+                ]
+
+                component "core/Gain" Gain20 {
+                    gain = "1/(1000*Rsnb)"
+                }
+                [
+                    position = 7368, 7552
+                    hide_name = True
+                ]
+
+                component "core/Product" Product21 {
+                }
+                [
+                    position = 7112, 7368
+                    hide_name = True
+                    scale = 1, -1
+                ]
+
+                component "core/Gain" Gain21 {
+                    gain = "nQc_P"
+                }
+                [
+                    position = 7208, 7368
+                    hide_name = True
+                ]
+
+                component "core/Sum" Sum9 {
+                    signs = "+++++"
+                }
+                [
+                    position = 7496, 7600
+                    rotation = right
+                    hide_name = True
+                ]
+
+                component "core/Limit" Limit12 {
+                    lower_limit = "0"
+                }
+                [
+                    position = 7008, 7416
+                    hide_name = True
+                ]
+
+                component "core/Signal switch" "Signal switch25" {
+                    criterion = "ctrl >= threshold"
+                    threshold = "0"
+                }
+                [
+                    position = 7368, 7384
+                    hide_name = True
+                    scale = 1, -1
+                ]
+
+                component "core/Gain" Gain22 {
+                    gain = "pQc_P"
+                }
+                [
+                    position = 7208, 7400
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant14 {
+                    execution_rate = "Ts"
+                    value = "Pc_T_pQ"
+                }
+                [
+                    position = 6864, 7816
+                    hide_name = True
+                ]
+
+                component "core/Signal switch" "Signal switch26" {
+                    criterion = "ctrl >= threshold"
+                    threshold = "0"
+                }
+                [
+                    position = 6976, 7840
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant15 {
+                    execution_rate = "Ts"
+                    value = "Pc_T_nQ"
+                }
+                [
+                    position = 6864, 7856
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant17 {
+                    execution_rate = "Ts"
+                    value = "pQc_T"
+                }
+                [
+                    position = 6920, 7496
+                    hide_name = True
+                ]
+
+                component "core/Signal switch" "Signal switch27" {
+                    criterion = "ctrl >= threshold"
+                    threshold = "0"
+                }
+                [
+                    position = 7008, 7520
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant18 {
+                    execution_rate = "Ts"
+                    value = "nQc_T"
+                }
+                [
+                    position = 6920, 7536
+                    hide_name = True
+                ]
+
+                component "core/Abs" Abs2 {
+                }
+                [
+                    position = 8080, 7976
+                    hide_name = True
+                ]
+
+                component "core/Abs" Abs3 {
+                }
+                [
+                    position = 8120, 8032
+                    rotation = left
+                    hide_name = True
+                ]
+
+                component "core/Sum" Sum14 {
+                    signs = "+-"
+                }
+                [
+                    position = 6416, 7416
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant19 {
+                    execution_rate = "Ts"
+                    value = "60"
+                }
+                [
+                    position = 6320, 7456
+                    hide_name = True
+                ]
+
+                component "core/Sum" Sum15 {
+                    signs = "+-"
+                }
+                [
+                    position = 6568, 7360
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant20 {
+                    execution_rate = "Ts"
+                }
+                [
+                    position = 6488, 7352
+                    hide_name = True
+                ]
+
+                component "core/Gain" Gain24 {
+                    gain = "Fc"
+                }
+                [
+                    position = 6488, 7416
+                    hide_name = True
+                ]
+
+                component "core/Edge Detection" "Edge Detection1" {
+                }
+                [
+                    position = 9216, 8328
+                    rotation = right
+                    hide_name = True
+                    size = 32, 32
+                ]
+
+                component "core/Rate Transition" "Rate Transition1" {
+                    execution_rate = "Tfst"
+                }
+                [
+                    position = 8848, 8280
+                    hide_name = True
+                    size = 32, 32
+                ]
+
+                component "core/C function" "C function1" {
+                    global_variables = "real counter;real m0;real m1;real m2;real corr;"
+                    init_fnc = "/*Begin code section*/
+counter=0;
+/*End code section*/"
+                    input_terminals = "real sync;real z;real zi;real zii;real Ts;real Ts_fast;"
+                    input_terminals_dimensions = "inherit;inherit;inherit;inherit;inherit;inherit"
+                    input_terminals_feedthrough = "True;True;True;True;True;True"
+                    input_terminals_show_labels = "True;True;True;True;True;True"
+                    output_fnc = "/*Begin code section*/
+counter = counter + Ts_fast;
+if (sync > 0 ) {
+    out = z;
+    counter = 0;
+
+}
+else {
+    corr = 1 - 0.11 * (Ts - Ts_fast)/Ts;
+    m2 = (zi - zii)/Ts;
+    m1 = (z - zi)/Ts;
+    m0 = m1 + (m1-m2);
+
+    out = z + counter * corr * m0;
+}
+
+if (counter >= Ts) {
+    counter = 0;
+}
+/*End code section*/"
+                    output_terminals_dimensions = "inherit"
+                    output_terminals_feedthrough = "True"
+                    output_terminals_show_labels = "True"
+                }
+                [
+                    position = 9144, 8536
+                    rotation = right
+                    hide_name = True
+                    size = 48, 128
+                ]
+
+                component "core/Unit Delay" "Unit Delay9" {
+                }
+                [
+                    position = 8848, 8344
+                    hide_name = True
+                ]
+
+                component "core/Unit Delay" "Unit Delay10" {
+                }
+                [
+                    position = 8952, 8400
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant21 {
+                    execution_rate = "Tfst"
+                    value = "Ts"
+                }
+                [
+                    position = 9080, 8448
+                    hide_name = True
+                ]
+
+                component "core/Rate Transition" "Rate Transition2" {
+                    execution_rate = "Tfst"
+                }
+                [
+                    position = 8952, 8344
+                    hide_name = True
+                    size = 32, 32
+                ]
+
+                component "core/Rate Transition" "Rate Transition3" {
+                    execution_rate = "Tfst"
+                }
+                [
+                    position = 9032, 8400
+                    hide_name = True
+                    size = 32, 32
+                ]
+
+                component "core/Signal switch" "Signal switch28" {
+                    criterion = "ctrl >= threshold"
+                    threshold = "Tfst"
+                }
+                [
+                    position = 9296, 8648
+                    hide_name = True
+                    scale = 1, -1
+                ]
+
+                component "core/Constant" Constant22 {
+                    execution_rate = "Tfst"
+                    value = "Ts"
+                }
+                [
+                    position = 9248, 8704
+                    hide_name = True
+                ]
+
+                component "core/Signal switch" "Signal switch29" {
+                    criterion = "ctrl >= threshold"
+                    threshold = "0"
+                }
+                [
+                    position = 9392, 8608
+                    hide_name = True
+                    scale = 1, -1
+                ]
+
+                component "core/Constant" Constant23 {
+                    execution_rate = "Tfst"
+                    value = "Tfast_en"
+                }
+                [
+                    position = 9336, 8696
+                    hide_name = True
+                ]
+
+                component "core/Product" Product22 {
+                }
+                [
+                    position = 7120, 7512
+                    hide_name = True
+                ]
+
+                component "core/Product" Product23 {
+                }
+                [
+                    position = 7088, 7848
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant24 {
+                    execution_rate = "Ts"
+                    value = "pQc_Q"
+                }
+                [
+                    position = 7112, 7264
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant25 {
+                    execution_rate = "Ts"
+                    value = "nQc_Q"
+                }
+                [
+                    position = 7112, 7216
+                    hide_name = True
+                ]
+
+                component "core/Signal switch" "Signal switch30" {
+                    criterion = "ctrl >= threshold"
+                    threshold = "0"
+                }
+                [
+                    position = 7184, 7248
+                    hide_name = True
+                    scale = 1, -1
+                ]
+
+                component "core/Product" Product24 {
+                }
+                [
+                    position = 7336, 7256
+                    hide_name = True
+                ]
+
+                component "core/Termination" Termination70 {
+                }
+                [
+                    position = 7784, 8224
+                    rotation = left
+                    hide_name = True
+                ]
+
+                component "core/Termination" Termination71 {
+                }
+                [
+                    position = 7816, 8264
+                    rotation = left
+                    hide_name = True
+                ]
+
+                component "core/Termination" Termination72 {
+                }
+                [
+                    position = 7792, 8408
+                    rotation = right
+                    hide_name = True
+                ]
+
+                component "core/Gain" Gain26 {
+                    gain = "1/(1000*Rsnb)"
+                }
+                [
+                    position = 7272, 7928
+                    hide_name = True
+                ]
+
+                component "core/Single phase PLL" "Single phase PLL1" {
+                    k_SOGI = "0.6"
+                    kd_PLL_HIGH = "0"
+                    kd_PLL_LOW = "0"
+                    kp_PLL_HIGH = "65.7"
+                    kp_PLL_LOW = "5.81e2"
+                    offset_Hz = "Freq"
+                }
+                [
+                    position = 7728, 8320
+                    hide_name = True
+                    size = 64, 98
+                ]
+
+                component "core/Trigonometric function" "Trigonometric function1" {
+                }
+                [
+                    position = 8024, 8224
+                    hide_name = True
+                ]
+
+                component "core/Gain" Gain25 {
+                    gain = "1.41421356"
+                }
+                [
+                    position = 8192, 8264
+                    hide_name = True
+                ]
+
+                component "core/Product" Product25 {
+                }
+                [
+                    position = 8304, 8232
+                    hide_name = True
+                    scale = 1, -1
+                ]
+
+                component "core/Capacitor" C1 {
+                    capacitance = "1/(Rsnb*2*np.pi*Freq)"
+                }
+                [
+                    position = 7976, 8984
+                ]
+
+                component "core/Trigonometric function" "Trigonometric function2" {
+                }
+                [
+                    position = 8192, 8344
+                    hide_name = True
+                ]
+
+                component "core/Sum" Sum16 {
+                    signs = "++"
+                }
+                [
+                    position = 8112, 8344
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant26 {
+                    execution_rate = "Ts"
+                    value = "-np.pi/2"
+                }
+                [
+                    position = 8016, 8360
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant28 {
+                    execution_rate = "Tfst"
+                    value = "Tfst"
+                }
+                [
+                    position = 9040, 8472
+                    hide_name = True
+                ]
+
+                component "core/Product" Product26 {
+                    signs = "**"
+                }
+                [
+                    position = 8408, 8352
+                    hide_name = True
+                ]
+
+                component "core/Sum" Sum17 {
+                    signs = "++"
+                }
+                [
+                    position = 8112, 8432
+                    hide_name = True
+                ]
+
+                component "core/Constant" Constant27 {
+                    execution_rate = "Ts"
+                    value = "np.pi/2"
+                }
+                [
+                    position = 8000, 8456
+                    hide_name = True
+                ]
+
+                component "core/Trigonometric function" "Trigonometric function3" {
+                }
+                [
+                    position = 8192, 8432
+                    hide_name = True
+                ]
+
+                component "core/Product" Product27 {
+                    signs = "**"
+                }
+                [
+                    position = 8304, 8424
+                    hide_name = True
+                    scale = 1, -1
+                ]
+
+                port P2 {
+                    position = right:2
+                    kind = pe
+                }
+                [
+                    position = 8192, 8784
+                    rotation = down
+                ]
+
+                port P3 {
+                    position = left:1
+                    kind = pe
+                }
+                [
+                    position = 7760, 8784
+                ]
+
+                port P {
+                    position = top:1
+                    kind = sp
+                    direction =  out
+                    sp_type {
+                        default = auto
+                        readonly = True
+                    }
+                }
+                [
+                    position = 6288, 7592
+                ]
+
+                port Q {
+                    position = top:2
+                    kind = sp
+                    direction =  out
+                    sp_type {
+                        default = auto
+                        readonly = True
+                    }
+                }
+                [
+                    position = 6288, 7664
+                ]
+
+                tag Goto1 {
+                    value = "ws"
+                    scope = local
+                    kind = sp
+                    direction = in
+                }
+                [
+                    position = 7888, 8320
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag From1 {
+                    value = "ws"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 6320, 7408
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag Goto2 {
+                    value = "kP"
+                    scope = local
+                    kind = sp
+                    direction = in
+                }
+                [
+                    position = 6368, 7592
+                    size = 60, 20
+                ]
+
+                tag Goto3 {
+                    value = "kQ"
+                    scope = local
+                    kind = sp
+                    direction = in
+                }
+                [
+                    position = 6368, 7664
+                    size = 60, 20
+                ]
+
+                tag From2 {
+                    value = "kP"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7288, 7888
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag From3 {
+                    value = "kP"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 6920, 7416
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag From4 {
+                    value = "kQ"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7432, 7440
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag From5 {
+                    value = "kQ"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 6712, 7640
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag From6 {
+                    value = "kQ"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7000, 7896
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag From7 {
+                    value = "kQ"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7248, 7264
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag Goto4 {
+                    value = "Va"
+                    scope = local
+                    kind = sp
+                    direction = in
+                }
+                [
+                    position = 7912, 9152
+                    rotation = down
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag From8 {
+                    value = "Va"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7616, 8320
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag From9 {
+                    value = "Va_rms"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 8104, 8264
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag From10 {
+                    value = "Va_rms"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7376, 8168
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag Goto5 {
+                    value = "Va_rms"
+                    scope = local
+                    kind = sp
+                    direction = in
+                }
+                [
+                    position = 7912, 9048
+                    rotation = down
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag Goto6 {
+                    value = "Va_rms_squared"
+                    scope = local
+                    kind = sp
+                    direction = in
+                }
+                [
+                    position = 7680, 8176
+                    hide_name = True
+                    size = 100, 20
+                ]
+
+                tag From11 {
+                    value = "Va_rms_squared"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7816, 8176
+                    hide_name = True
+                    size = 97, 20
+                ]
+
+                tag From12 {
+                    value = "Va_rms_squared"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7248, 7552
+                    hide_name = True
+                    size = 97, 20
+                ]
+
+                tag From13 {
+                    value = "Va_rms_squared"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7160, 7928
+                    hide_name = True
+                    size = 97, 20
+                ]
+
+                tag From14 {
+                    value = "Va_rms_squared"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7872, 7856
+                    hide_name = True
+                    size = 97, 20
+                ]
+
+                tag Goto7 {
+                    value = "Q_sign"
+                    scope = local
+                    kind = sp
+                    direction = in
+                }
+                [
+                    position = 6912, 7640
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag From15 {
+                    value = "Q_sign"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7312, 7440
+                    hide_name = True
+                    size = 57, 20
+                ]
+
+                tag From16 {
+                    value = "Q_sign"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7120, 7312
+                    hide_name = True
+                    size = 57, 20
+                ]
+
+                tag From17 {
+                    value = "Q_sign"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 6952, 7448
+                    hide_name = True
+                    size = 57, 20
+                ]
+
+                tag From18 {
+                    value = "Q_sign"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 6928, 7768
+                    hide_name = True
+                    size = 57, 20
+                ]
+
+                tag From19 {
+                    value = "Q_sign"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7032, 7664
+                    hide_name = True
+                    size = 57, 20
+                ]
+
+                tag Goto8 {
+                    value = "Ia_load"
+                    scope = local
+                    kind = sp
+                    direction = in
+                }
+                [
+                    position = 9528, 8608
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                tag From20 {
+                    value = "Ia_load"
+                    scope = local
+                    kind = sp
+                    direction = out
+                }
+                [
+                    position = 7896, 8744
+                    hide_name = True
+                    size = 60, 20
+                ]
+
+                junction Junction1 sp
+                [
+                    position = 7496, 8168
+                ]
+
+                junction Junction2 pe
+                [
+                    position = 8080, 8784
+                ]
+
+                junction Junction10 sp
+                [
+                    position = 8048, 8152
+                ]
+
+                junction Junction11 sp
+                [
+                    position = 8120, 8072
+                ]
+
+                junction Junction62 sp
+                [
+                    position = 7496, 7728
+                ]
+
+                junction Junction50 sp
+                [
+                    position = 8144, 7832
+                ]
+
+                junction Junction51 sp
+                [
+                    position = 8112, 7736
+                ]
+
+                junction Junction74 sp
+                [
+                    position = 7856, 7728
+                ]
+
+                junction Junction78 sp
+                [
+                    position = 6928, 7696
+                ]
+
+                junction Junction82 sp
+                [
+                    position = 7496, 7680
+                ]
+
+                junction Junction84 sp
+                [
+                    position = 7160, 7368
+                ]
+
+                junction Junction92 sp
+                [
+                    position = 7760, 8120
+                ]
+
+                junction Junction95 sp
+                [
+                    position = 6656, 7360
+                ]
+
+                junction Junction96 sp
+                [
+                    position = 6784, 7640
+                ]
+
+                junction Junction97 pe
+                [
+                    position = 7856, 8784
+                ]
+
+                junction Junction101 sp
+                [
+                    position = 9168, 8280
+                ]
+
+                junction Junction102 sp
+                [
+                    position = 8768, 8280
+                ]
+
+                junction Junction109 sp
+                [
+                    position = 8912, 8344
+                ]
+
+                junction Junction112 sp
+                [
+                    position = 7056, 7416
+                ]
+
+                junction Junction130 pe
+                [
+                    position = 7856, 8888
+                ]
+
+                junction Junction131 pe
+                [
+                    position = 8080, 8888
+                ]
+
+                junction Junction133 sp
+                [
+                    position = 8376, 7816
+                ]
+
+                junction Junction121 sp
+                [
+                    position = 8248, 8264
+                ]
+
+                junction Junction127 sp
+                [
+                    position = 8248, 8360
+                ]
+
+                junction Junction129 sp
+                [
+                    position = 7960, 8336
+                ]
+
+                junction Junction137 pe
+                [
+                    position = 8080, 8984
+                ]
+
+                junction Junction138 pe
+                [
+                    position = 7856, 8984
+                ]
+
+                junction Junction139 pe
+                [
+                    position = 8080, 9088
+                ]
+
+                junction Junction140 pe
+                [
+                    position = 7856, 9088
+                ]
+
+                junction Junction141 sp
+                [
+                    position = 7960, 8336
+                ]
+
+                junction Junction142 sp
+                [
+                    position = 9248, 8592
+                ]
+
+                junction Junction143 sp
+                [
+                    position = 9216, 8280
+                ]
+
+                connect Limit1.out Junction1 as Connection9
+                connect Junction1 Product2.in1 as Connection10
+                connect "Discrete Transfer Function1.out" Product3.in1 as Connection16
+                connect Product1.out Limit2.in as Connection44
+                connect Gain2.out Product1.in as Connection47
+                connect Constant2.out Product4.in1 as Connection54
+                connect Comparator1.out "Signal switch20.in2" as Connection57
+                connect Junction10 Limit2.out as Connection59
+                [
+                    position = 0, 0
+                ]
+                connect "Signal switch20.in1" Junction10 as Connection60
+                connect Product4.out Junction11 as Connection62
+                connect "Signal switch20.in" Junction11 as Connection64
+                connect Limit10.out Gain16.in as Connection299
+                connect Gain16.out Sign1.in as Connection315
+                connect Limit10.in Junction62 as Connection319
+                [
+                    position = 0, 0
+                ]
+                connect Limit11.out Sign2.in as Connection320
+                connect Gain15.out Product14.in as Connection227
+                connect Product14.out Limit7.in as Connection228
+                connect Comparator4.out "Signal switch23.in2" as Connection229
+                connect Limit7.out Junction50 as Connection233
+                connect Junction50 "Signal switch23.in1" as Connection234
+                connect Comparator4.in1 Junction50 as Connection235
+                connect "Signal switch23.in" Junction51 as Connection236
+                connect Product15.out Junction51 as Connection238
+                connect Constant8.out Product15.in1 as Connection239
+                connect "Signal switch23.out" "Discrete Transfer Function4.in" as Connection243
+                connect Junction51 Comparator4.in2 as Connection253
+                [
+                    position = 0, 0
+                ]
+                connect Abs1.in Junction62 as Connection395
+                [
+                    position = 0, 0
+                ]
+                connect Product15.in Junction74 as Connection396
+                connect Junction74 Abs1.out as Connection397
+                connect Gain15.in Junction74 as Connection398
+                connect "Signal switch24.in" Gain18.out as Connection419
+                [
+                    position = 0, 0
+                ]
+                connect "Signal switch24.out" Sum8.in as Connection420
+                connect Gain19.out "Signal switch24.in1" as Connection422
+                connect Product20.out Junction78 as Connection423
+                connect Junction78 Gain18.in as Connection424
+                connect Gain19.in Junction78 as Connection425
+                connect Product19.in2 Sign2.out as Connection430
+                [
+                    position = 0, 0
+                ]
+                connect Limit11.in Junction82 as Connection444
+                connect Junction82 Junction62 as Connection445
+                [
+                    position = 0, 0
+                ]
+                connect Sum9.out Junction82 as Connection446
+                connect Product21.out Junction84 as Connection461
+                [
+                    position = 0, 0
+                ]
+                connect Junction84 Gain21.in as Connection462
+                connect Gain22.in Junction84 as Connection463
+                connect Gain22.out "Signal switch25.in" as Connection464
+                connect Gain21.out "Signal switch25.in1" as Connection468
+                [
+                    position = 0, 0
+                ]
+                connect Junction92 Gain2.in as Connection509
+                [
+                    position = 0, 0
+                ]
+                connect Product4.in Junction92 as Connection510
+                connect Comparator1.in1 Abs2.out as Connection511
+                connect Abs2.in Junction10 as Connection512
+                connect Junction11 Abs3.in as Connection513
+                connect Abs3.out Comparator1.in2 as Connection514
+                connect Junction92 Sum8.out as Connection515
+                [
+                    position = 0, 0
+                ]
+                connect From1 Sum14.in as Connection523
+                connect Constant19.out Sum14.in1 as Connection524
+                connect Constant20.out Sum15.in as Connection525
+                connect Gain24.in Sum14.out as Connection526
+                connect Gain24.out Sum15.in1 as Connection527
+                connect Sum15.out Junction95 as Connection529
+                connect P Goto2 as Connection532
+                connect Q Goto3 as Connection533
+                connect From3 Limit12.in as Connection535
+                connect Sign3.in Junction96 as Connection538
+                connect Junction96 Product20.in as Connection539
+                [
+                    position = 0, 0
+                ]
+                connect From5 Junction96 as Connection540
+                connect "Signal switch20.out" "Discrete Transfer Function1.in" as Connection554
+                connect Constant21.out "C function1.Ts" as Connection605
+                connect Junction101 "C function1.z" as Connection607
+                [
+                    position = 0, 0
+                ]
+                connect "Rate Transition3.in" "Unit Delay10.out" as Connection615
+                connect "Rate Transition2.out" "C function1.zi" as Connection616
+                connect "Rate Transition3.out" "C function1.zii" as Connection617
+                connect "C function1.sync" "Edge Detection1.Out1" as Connection618
+                [
+                    position = 0, 0
+                ]
+                connect "Rate Transition1.in" Junction102 as Connection622
+                [
+                    position = 0, 0
+                ]
+                connect Constant22.out "Signal switch28.in2" as Connection624
+                connect Sum5.out Junction102 as Connection649
+                [
+                    position = 0, 0
+                ]
+                connect Constant23.out "Signal switch29.in2" as Connection653
+                connect "Signal switch28.out" "Signal switch29.in" as Connection660
+                [
+                    position = 0, 0
+                ]
+                connect Isp1.p_node Junction2 as Connection670
+                [
+                    position = 0, 0
+                ]
+                connect Isp1.n_node Junction97 as Connection669
+                [
+                    position = 0, 0
+                ]
+                connect Junction102 "Unit Delay9.in" as Connection683
+                [
+                    position = 0, 0
+                ]
+                connect "Rate Transition2.in" Junction109 as Connection684
+                connect Junction109 "Unit Delay9.out" as Connection685
+                connect "Unit Delay10.in" Junction109 as Connection686
+                connect Junction95 Product21.in1 as Connection697
+                [
+                    position = 0, 0
+                ]
+                connect "Signal switch27.out" Product22.in1 as Connection701
+                connect Product21.in Junction112 as Connection704
+                connect Junction112 Limit12.out as Connection705
+                [
+                    position = 0, 0
+                ]
+                connect Product22.in Junction112 as Connection706
+                connect Product23.in "Signal switch26.out" as Connection710
+                connect From6 Product23.in1 as Connection711
+                [
+                    position = 0, 0
+                ]
+                connect Constant24.out "Signal switch30.in" as Connection713
+                connect Constant25.out "Signal switch30.in1" as Connection714
+                connect "Single phase PLL1.f" Goto1 as Connection881
+                connect "Signal switch30.out" Product24.in as Connection718
+                connect From7 Product24.in1 as Connection719
+                connect "Single phase PLL1.d" Termination70.in as Connection882
+                connect "Single phase PLL1.q" Termination71.in as Connection883
+                connect Product20.in1 Junction95 as Connection721
+                [
+                    position = 0, 0
+                ]
+                connect "Single phase PLL1.sin(wt)" Termination72.in as Connection884
+                connect "Signal switch28.in" "C function1.out" as Connection724
+                [
+                    position = 0, 0
+                ]
+                connect Gain20.out Sum9.in4 as Connection869
+                [
+                    position = 0, 0
+                ]
+                connect Constant17.out "Signal switch27.in" as Connection875
+                connect Constant18.out "Signal switch27.in1" as Connection876
+                connect Constant14.out "Signal switch26.in" as Connection878
+                connect Constant15.out "Signal switch26.in1" as Connection879
+                connect Product3.in Product25.out as Connection767
+                connect Constant26.out Sum16.in1 as Connection771
+                connect Sum16.out "Trigonometric function2.in" as Connection772
+                connect "Trigonometric function1.out" Product25.in1 as Connection773
+                [
+                    position = 0, 0
+                ]
+                connect Constant28.out "C function1.Ts_fast" as Connection837
+                connect R1.p_node Junction130 as Connection838
+                connect Junction130 Junction97 as Connection839
+                [
+                    position = 0, 0
+                ]
+                connect Junction131 Junction2 as Connection842
+                [
+                    position = 0, 0
+                ]
+                connect R1.n_node Junction131 as Connection843
+                connect Product25.in Junction121 as Connection786
+                connect "Discrete Transfer Function4.out" Junction133 as Connection847
+                connect Junction121 Gain25.out as Connection787
+                connect Product17.in Junction133 as Connection849
+                connect "Trigonometric function2.out" Product26.in as Connection793
+                [
+                    position = 0, 0
+                ]
+                connect Product19.in1 Junction133 as Connection860
+                [
+                    position = 0, 0
+                ]
+                connect Constant27.out Sum17.in1 as Connection800
+                connect Junction1 Product2.in as Connection866
+                [
+                    position = 0, 0
+                ]
+                connect Sum17.out "Trigonometric function3.in" as Connection808
+                connect "Trigonometric function3.out" Product27.in as Connection809
+                connect Product26.in1 Junction127 as Connection813
+                connect Junction127 Junction121 as Connection814
+                connect Product27.in1 Junction127 as Connection815
+                connect Product19.in Product26.out as Connection818
+                [
+                    position = 0, 0
+                ]
+                connect "Trigonometric function1.in" Junction129 as Connection823
+                [
+                    position = 0, 0
+                ]
+                connect "Single phase PLL1.wt" Junction129 as Connection825
+                connect Product22.out Sum9.in3 as Connection889
+                connect From4 Sum9.in2 as Connection890
+                connect "Signal switch25.out" Sum9.in1 as Connection891
+                connect Product24.out Sum9.in as Connection892
+                connect Gain26.out Sum8.in3 as Connection894
+                connect C1.n_node Junction137 as Connection896
+                connect Junction137 Junction131 as Connection897
+                connect C1.p_node Junction138 as Connection900
+                connect Junction138 Junction130 as Connection901
+                connect P2 Junction2 as Connection903
+                connect Varms.n_node Junction139 as Connection904
+                connect Junction139 Junction137 as Connection905
+                connect Va.n_node Junction139 as Connection906
+                connect P3 Junction97 as Connection907
+                connect Varms.p_node Junction140 as Connection908
+                connect Junction140 Junction138 as Connection909
+                connect Va.p_node Junction140 as Connection910
+                connect Goto4 Va.out as Connection914
+                connect From8 "Single phase PLL1.In" as Connection915
+                connect From9 Gain25.in as Connection917
+                connect Limit1.in From10 as Connection918
+                connect Goto5 Varms.out as Connection919
+                connect Sum16.in Junction141 as Connection921
+                [
+                    position = 0, 0
+                    breakpoints = 7984, 8336
+                ]
+                connect Junction141 Junction129 as Connection922
+                connect Sum17.in Junction141 as Connection923
+                connect Sign1.out Product17.in1 as Connection925
+                connect Product27.out Product17.in2 as Connection926
+                connect From11 Product1.in1 as Connection931
+                connect From12 Gain20.in as Connection933
+                connect From13 Gain26.in as Connection935
+                connect Goto6 Product2.out as Connection936
+                connect From14 Product14.in1 as Connection937
+                connect From15 "Signal switch25.in2" as Connection942
+                connect From16 "Signal switch30.in2" as Connection944
+                connect From17 "Signal switch27.in2" as Connection946
+                connect Goto7 Sign3.out as Connection947
+                connect From18 "Signal switch26.in2" as Connection948
+                connect From19 "Signal switch24.in2" as Connection949
+                connect Product23.out Sum8.in1 as Connection950
+                connect From2 Sum8.in2 as Connection951
+                connect Product3.out Sum5.in2 as Connection952
+                connect Product17.out Sum5.in1 as Connection953
+                connect Product19.out Sum5.in as Connection954
+                connect Junction101 "Rate Transition1.out" as Connection956
+                connect "Signal switch28.in1" Junction142 as Connection957
+                connect Junction142 "Signal switch29.in1" as Connection958
+                connect Junction101 Junction143 as Connection959
+                connect Junction143 "Edge Detection1.In1" as Connection960
+                connect Junction142 Junction143 as Connection961
+                connect Goto8 "Signal switch29.out" as Connection965
+                connect From20 Isp1.in as Connection966
+
+                mask {
+                    description = "<html><head><meta name=\"qrichtext\" content=\"1\"></meta><style type=\"text/css\">p, li { white-space: pre-wrap; }</style></head><body style=\"\"><p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><br></br></p></body></html>"
+
+                    kVLine {
+                        label = "Nominal line voltage"
+                        widget = edit
+                        type = generic
+                        default_value = "Vn_3ph_CPL"
+                        unit = "kV"
+                        group = "Load Parameters:1"
+                    }
+
+                    VLL {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    kVLL {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    kP_tot {
+                        label = "Active power"
+                        widget = edit
+                        type = generic
+                        default_value = "P_CPL"
+                        unit = "kW"
+                        group = "Load Parameters"
+                    }
+
+                    kP {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    P {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    SS {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    Rsnb {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    kQ_tot {
+                        label = "Reactive power"
+                        widget = edit
+                        type = generic
+                        default_value = "Q_CPL"
+                        unit = "kVAR"
+                        group = "Load Parameters"
+                    }
+
+                    kQ {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    Q {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    Ts {
+                        label = "Execution Rate"
+                        widget = edit
+                        type = generic
+                        default_value = "Ts"
+                        unit = "s"
+                        group = "Execution rate:2"
+                    }
+
+                    Fast_con {
+                        label = "Fast execution rate output conditioning"
+                        widget = checkbox
+                        type = bool
+                        default_value = "True"
+                        group = "Execution rate"
+                        no_evaluate
+                    }
+
+                    Tfst {
+                        label = "Fast execution rate"
+                        widget = edit
+                        type = generic
+                        default_value = "Tfast"
+                        unit = "s"
+                        group = "Execution rate"
+                    }
+
+                    Tfast_en {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    pQc_P {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    nQc_P {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    pQc_T {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    nQc_T {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    pQc_Q {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    nQc_Q {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    Pc_pQ {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    Pc_nQ {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    Pc_T_pQ {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    Pc_T_nQ {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    Pc_T {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    Fc {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    Freq {
+                        label = "Nominal frequency"
+                        widget = edit
+                        type = generic
+                        default_value = "fn"
+                        unit = "Hz"
+                        group = "Load Parameters"
+                    }
+
+                    inv_ph {
+                        widget = edit
+                        type = generic
+                        default_value = "0"
+                        nonvisible
+                    }
+
+                    CPL_curr {
+                        label = "Current limit "
+                        widget = edit
+                        type = generic
+                        default_value = "CPL_LMT"
+                        unit = "pu"
+                        group = "Load Parameters"
+                    }
+
+                    CODE open
+                        from typhoon.apps.schematic_editor.dialogs.component_property_dialogs.general import RegularComponentPropertiesDialog
+
+                        dialog = RegularComponentPropertiesDialog(
+                            component=component,
+                            property_container=component.masks[-1],
+                            current_diagram=current_diagram
+                        )
+                        dialog.exec_()
+
+                    ENDCODE
+
+                    CODE pre_compile
+                        # HEADER START
+                        kVLine = mdl.get_property_value(mdl.prop(item_handle, "kVLine"))
+                        VLL = mdl.get_property_value(mdl.prop(item_handle, "VLL"))
+                        kVLL = mdl.get_property_value(mdl.prop(item_handle, "kVLL"))
+                        kP_tot = mdl.get_property_value(mdl.prop(item_handle, "kP_tot"))
+                        kP = mdl.get_property_value(mdl.prop(item_handle, "kP"))
+                        P = mdl.get_property_value(mdl.prop(item_handle, "P"))
+                        SS = mdl.get_property_value(mdl.prop(item_handle, "SS"))
+                        Rsnb = mdl.get_property_value(mdl.prop(item_handle, "Rsnb"))
+                        kQ_tot = mdl.get_property_value(mdl.prop(item_handle, "kQ_tot"))
+                        kQ = mdl.get_property_value(mdl.prop(item_handle, "kQ"))
+                        Q = mdl.get_property_value(mdl.prop(item_handle, "Q"))
+                        Ts = mdl.get_property_value(mdl.prop(item_handle, "Ts"))
+                        Fast_con = mdl.get_property_value(mdl.prop(item_handle, "Fast_con"))
+                        Tfst = mdl.get_property_value(mdl.prop(item_handle, "Tfst"))
+                        Tfast_en = mdl.get_property_value(mdl.prop(item_handle, "Tfast_en"))
+                        pQc_P = mdl.get_property_value(mdl.prop(item_handle, "pQc_P"))
+                        nQc_P = mdl.get_property_value(mdl.prop(item_handle, "nQc_P"))
+                        pQc_T = mdl.get_property_value(mdl.prop(item_handle, "pQc_T"))
+                        nQc_T = mdl.get_property_value(mdl.prop(item_handle, "nQc_T"))
+                        pQc_Q = mdl.get_property_value(mdl.prop(item_handle, "pQc_Q"))
+                        nQc_Q = mdl.get_property_value(mdl.prop(item_handle, "nQc_Q"))
+                        Pc_pQ = mdl.get_property_value(mdl.prop(item_handle, "Pc_pQ"))
+                        Pc_nQ = mdl.get_property_value(mdl.prop(item_handle, "Pc_nQ"))
+                        Pc_T_pQ = mdl.get_property_value(mdl.prop(item_handle, "Pc_T_pQ"))
+                        Pc_T_nQ = mdl.get_property_value(mdl.prop(item_handle, "Pc_T_nQ"))
+                        Pc_T = mdl.get_property_value(mdl.prop(item_handle, "Pc_T"))
+                        Fc = mdl.get_property_value(mdl.prop(item_handle, "Fc"))
+                        Freq = mdl.get_property_value(mdl.prop(item_handle, "Freq"))
+                        inv_ph = mdl.get_property_value(mdl.prop(item_handle, "inv_ph"))
+                        CPL_curr = mdl.get_property_value(mdl.prop(item_handle, "CPL_curr"))
+                        # HEADER STOP
+                        from typhoon.api.schematic_editor.const import ITEM_COMPONENT
+                        import numpy
+                        import math
+
+                        kVLL = kVLine/(3**0.5)
+                        VLL = kVLL * 1000
+                        kP = kP_tot / 3
+                        kQ = kQ_tot / 3
+                        P = kP * 1000
+                        Q = kQ * 1000
+                        SS = (P*P + Q*Q)**0.5
+
+                        if SS==0:
+                            Rsnb = 100000
+                        else:
+                            Rsnb = 30 * (VLL*VLL/(SS))
+
+                        if Fast_con:
+                            Tfast_en = 1
+                        else:
+                            Tfast_en = 0
+
+                        pQc_P = -1/9.7
+                        nQc_P = -0.097
+
+                        pQc_T = -0.015*(Ts-600e-6)/Ts
+                        nQc_T = -0.012*(Ts-600e-6)/Ts
+
+                        pQc_Q = 0.0266
+                        nQc_Q = 0.014
+
+                        Pc_pQ = 0.095
+                        Pc_nQ = 0.0933
+
+                        Pc_T = 0.005*(Ts-600e-6)/Ts
+
+                        Pc_T_pQ = 0.0075*(Ts-600e-6)/Ts
+                        Pc_T_nQ = 0.01*(Ts-600e-6)/Ts
+
+                        Fc = -0*1/15
+
+                        mdl.set_property_value(mdl.prop(item_handle, "kVLine"), kVLine)
+                        mdl.set_property_value(mdl.prop(item_handle, "kVLL"), kVLL)
+                        mdl.set_property_value(mdl.prop(item_handle, "kP"), kP)
+                        mdl.set_property_value(mdl.prop(item_handle, "VLL"), VLL)
+                        mdl.set_property_value(mdl.prop(item_handle, "P"), P)
+                        mdl.set_property_value(mdl.prop(item_handle, "Rsnb"), Rsnb)
+                        mdl.set_property_value(mdl.prop(item_handle, "kQ"), kQ)
+                        mdl.set_property_value(mdl.prop(item_handle, "Q"), Q)
+                        mdl.set_property_value(mdl.prop(item_handle, "Ts"), Ts)
+                        mdl.set_property_value(mdl.prop(item_handle, "kP_tot"), kP_tot)
+                        mdl.set_property_value(mdl.prop(item_handle, "kQ_tot"), kQ_tot)
+                        mdl.set_property_value(mdl.prop(item_handle, "Tfast_en"), Tfast_en)
+
+                        mdl.set_property_value(mdl.prop(item_handle, "pQc_P"), pQc_P)
+                        mdl.set_property_value(mdl.prop(item_handle, "nQc_P"), nQc_P)
+
+                        mdl.set_property_value(mdl.prop(item_handle, "pQc_T"), pQc_T)
+                        mdl.set_property_value(mdl.prop(item_handle, "nQc_T"), nQc_T)
+
+                        mdl.set_property_value(mdl.prop(item_handle, "pQc_Q"), pQc_Q)
+                        mdl.set_property_value(mdl.prop(item_handle, "nQc_Q"), nQc_Q)
+
+                        mdl.set_property_value(mdl.prop(item_handle, "Pc_pQ"), Pc_pQ)
+                        mdl.set_property_value(mdl.prop(item_handle, "Pc_nQ"), Pc_nQ)
+
+                        mdl.set_property_value(mdl.prop(item_handle, "Pc_T"), Pc_T)
+
+                        mdl.set_property_value(mdl.prop(item_handle, "Pc_T_pQ"), Pc_T_pQ)
+                        mdl.set_property_value(mdl.prop(item_handle, "Pc_T_nQ"), Pc_T_nQ)
+
+                        mdl.set_property_value(mdl.prop(item_handle, "Fc"), Fc)
+                        mdl.set_property_value(mdl.prop(item_handle, "inv_ph"), inv_ph)
+
+                        mdl.set_property_value(mdl.prop(item_handle, "Freq"), Freq)
+                        mdl.set_property_value(mdl.prop(item_handle, "SS"), SS)
+                        mdl.set_property_value(mdl.prop(item_handle, "Tfst"), Tfst)
+
+                        mdl.set_property_value(mdl.prop(item_handle, "CPL_curr"), CPL_curr)
+                    ENDCODE
+                }
+            }
+            [
+                position = 8216, 8256
+                size = 48, 48
+            ]
         }
         [
             position = 4344, 3880
@@ -31583,26 +28687,42 @@ if (counter >= Ts) {
     }
 
     logically_deleted {
-        "Load.CPL"
-        "Load.TS_module"
+        "VSConverter.TS_module"
+        "VSConverter.T_switch"
+        "VSConverter.Constant102"
+        "VSConverter.Connection3"
+        "VSConverter.Connection5658"
+        "Generator.TS_module"
+        "Generator.T_switch"
+        "Generator.Constant102"
+        "Generator.Connection3"
+        "Generator.Connection5116"
     }
 
     default {
-        gen_abs {
+        "core/1D look-up table" {
+            in_vec_x = "np.arange(-5,6)"
+            out_vec_f_x = "np.arange(-5,6)**2"
+            table_impl = "Equidistant"
+            ext_mode = "Clip"
             execution_rate = "inherit"
         }
 
-        gen_bus_join {
+        "core/Abs" {
+            execution_rate = "inherit"
+        }
+
+        "core/Bus Join" {
             inputs = "2"
             execution_rate = "inherit"
         }
 
-        gen_bus_split {
+        "core/Bus Split" {
             outputs = "2"
             execution_rate = "inherit"
         }
 
-        gen_c_function {
+        "core/C function" {
             input_terminals = "real in;"
             input_terminals_show_labels = "False;"
             input_terminals_feedthrough = "True;"
@@ -31619,147 +28739,31 @@ if (counter >= Ts) {
             execution_rate = "inherit"
         }
 
-        gen_comparator {
-            execution_rate = "inherit"
-        }
-
-        gen_data_type_conversion {
-            output_type = "real"
-            execution_rate = "inherit"
-        }
-
-        gen_gain {
-            gain = "1"
-            multiplication = "Element-wise(K.*u)"
-            _tunable = "False"
-            execution_rate = "inherit"
-        }
-
-        gen_integrator {
-            show_reset = "none"
-            reset_type = "asynchronous"
-            show_init_condition = "internal"
-            init_value = "0"
-            limit_output = "False"
-            limit_upper = "inf"
-            limit_lower = "-inf"
-            show_state = "False"
-            state_port_type = "inherit"
-            execution_rate = "inherit"
-        }
-
-        gen_limiter {
-            upper_limit = "[\'inf\']"
-            lower_limit = "[\'-inf\']"
-            execution_rate = "inherit"
-        }
-
-        gen_logic_op {
-            operator = "AND"
-            inputs = "2"
-            execution_rate = "inherit"
-        }
-
-        gen_math_fnc {
-            mathematical_fn = "exponential"
-            execution_rate = "inherit"
-        }
-
-        gen_probe {
-            addr = "0"
-            override_signal_name = "False"
-            signal_name = ""
-            signal_type = "generic"
-            streaming_en = "False"
-            streaming_er_idx = "0"
-            execution_rate = "inherit"
-        }
-
-        gen_product {
-            signs = "2"
-            execution_rate = "inherit"
-        }
-
-        gen_rate_limiter {
-            rising_limit = "1"
-            falling_limit = "-1"
-            execution_rate = "inherit"
-        }
-
-        gen_rel_op {
-            relational_op = "=="
-            execution_rate = "inherit"
-        }
-
-        gen_sign {
-            execution_rate = "inherit"
-        }
-
-        gen_sum {
-            signs = "2"
-            execution_rate = "inherit"
-        }
-
-        gen_terminator {
-            execution_rate = "inherit"
-        }
-
-        gen_trigonometric {
-            trigonometric_fn = "sin"
-            angle = "Radians"
-            execution_rate = "inherit"
-        }
-
-        gen_z_domain_transfer {
-            domain = "Z-domain"
-            method = "Zero-order hold"
-            b_coeff = "[1,1]"
-            a_coeff = "[1,1]"
-            signal_out_type = "inherit"
-            execution_rate = "inherit"
-        }
-
-        lut_1d {
-            in_vec_x = "np.arange(-5,6)"
-            out_vec_f_x = "np.arange(-5,6)**2"
-            table_impl = "Equidistant"
-            ext_mode = "Clip"
-            execution_rate = "inherit"
-        }
-
-        pas_capacitor {
+        "core/Capacitor" {
             capacitance = "1e-6"
             initial_voltage = "0"
             pole_shift_ignore = "False"
             visible = "True"
         }
 
-        pas_inductor {
-            inductance = "1e-3"
-            initial_current = "0.0"
-            pole_shift_ignore = "False"
-            visible = "True"
-        }
-
-        pas_resistor {
-            resistance = "1"
-            param_set = ""
-        }
-
-        src_clock {
+        "core/Clock" {
             enb_reset = "False"
             reset_at = "1.0"
             execution_rate = "100e-6"
         }
 
-        src_constant {
+        "core/Comparator" {
+            execution_rate = "inherit"
+        }
+
+        "core/Constant" {
             value = "1"
             signal_type = "real"
             execution_rate = "100e-6"
             _tunable = "False"
         }
 
-        src_current {
+        "core/Current Source" {
             sig_input = "False"
             type = "signal generator"
             param_set = "1phase"
@@ -31781,7 +28785,135 @@ if (counter >= Ts) {
             init_phase = "0.0"
         }
 
-        src_step {
+        "core/Data Type Conversion" {
+            output_type = "real"
+            execution_rate = "inherit"
+        }
+
+        "core/Discrete Transfer Function" {
+            domain = "Z-domain"
+            method = "Zero-order hold"
+            b_coeff = "[1,1]"
+            a_coeff = "[1,1]"
+            signal_out_type = "inherit"
+            execution_rate = "inherit"
+        }
+
+        "core/Gain" {
+            gain = "1"
+            multiplication = "Element-wise(K.*u)"
+            _tunable = "False"
+            execution_rate = "inherit"
+        }
+
+        "core/Inductor" {
+            inductance = "1e-3"
+            initial_current = "0.0"
+            pole_shift_ignore = "False"
+            visible = "True"
+        }
+
+        "core/Integrator" {
+            show_reset = "none"
+            reset_type = "asynchronous"
+            show_init_condition = "internal"
+            init_value = "0"
+            limit_output = "False"
+            limit_upper = "inf"
+            limit_lower = "-inf"
+            show_state = "False"
+            state_port_type = "inherit"
+            execution_rate = "inherit"
+        }
+
+        "core/Limit" {
+            upper_limit = "[\'inf\']"
+            lower_limit = "[\'-inf\']"
+            execution_rate = "inherit"
+        }
+
+        "core/Logical operator" {
+            operator = "AND"
+            inputs = "2"
+            execution_rate = "inherit"
+        }
+
+        "core/Mathematical function" {
+            mathematical_fn = "exponential"
+            execution_rate = "inherit"
+        }
+
+        "core/Multiport signal switch" {
+            number_of_input_terminals = "2"
+            execution_rate = "inherit"
+        }
+
+        "core/Open Circuit" {
+            circuit_connector = "false"
+            pesb_flag = "false"
+            type = "none"
+        }
+
+        "core/Probe" {
+            signal_access = "inherit"
+            addr = "0"
+            override_signal_name = "False"
+            signal_name = ""
+            signal_type = "generic"
+            streaming_en = "False"
+            streaming_er_idx = "0"
+            execution_rate = "inherit"
+        }
+
+        "core/Product" {
+            signs = "2"
+            execution_rate = "inherit"
+        }
+
+        "core/Rate Limiter" {
+            rising_limit = "1"
+            falling_limit = "-1"
+            execution_rate = "inherit"
+        }
+
+        "core/Relational operator" {
+            relational_op = "=="
+            execution_rate = "inherit"
+        }
+
+        "core/Resistor" {
+            resistance = "1"
+            param_set = ""
+        }
+
+        "core/Round" {
+            round_fn = "floor"
+            execution_rate = "inherit"
+        }
+
+        "core/Short Circuit" {
+            circuit_connector = "false"
+            pesb_flag = "false"
+            type = "none"
+            r_calc_msr = ""
+        }
+
+        "core/Signal switch" {
+            criterion = "ctrl > threshold"
+            threshold = "0.5"
+            execution_rate = "inherit"
+        }
+
+        "core/Sinusoidal Source" {
+            amplitude = "1"
+            dc_offset = "0"
+            frequency = "50"
+            phase = "0"
+            execution_rate = "100e-6"
+            _tunable = "False"
+        }
+
+        "core/Step" {
             step_time = "1"
             initial_value = "0"
             final_value = "1"
@@ -31789,7 +28921,28 @@ if (counter >= Ts) {
             execution_rate = "100e-6"
         }
 
-        src_voltage {
+        "core/Sum" {
+            signs = "2"
+            execution_rate = "inherit"
+        }
+
+        "core/Termination" {
+            execution_rate = "inherit"
+        }
+
+        "core/Trigonometric function" {
+            trigonometric_fn = "sin"
+            angle = "Radians"
+            execution_rate = "inherit"
+        }
+
+        "core/Unit Delay" {
+            init_value = "0"
+            signal_out_type = "inherit"
+            execution_rate = "inherit"
+        }
+
+        "core/Voltage Source" {
             sig_input = "False"
             type = "signal generator"
             param_set = "1phase"
@@ -31811,24 +28964,47 @@ if (counter >= Ts) {
             init_phase = "0.0"
         }
 
-        sys_mp_signal_switch {
-            number_of_input_terminals = "2"
-            execution_rate = "inherit"
-        }
-
-        sys_signal_switch {
-            criterion = "ctrl >= threshold"
-            threshold = "0"
-            execution_rate = "inherit"
-        }
-
-        tm_delay {
-            init_value = "0"
-            signal_out_type = "inherit"
-            execution_rate = "inherit"
+        "OpenDSS/CIL" {
+            fn = "fn"
+            conn_type = "Y"
+            ground_connected = "False"
+            set_balanced = "True"
+            Vn_3ph = "Vn_3ph_CPL"
+            Sn_3ph = "Sn_3ph"
+            pf_mode_3ph = "Lag"
+            pf_3ph = "pf_3ph_set"
+            VAn = "0*1000/(3**0.5)"
+            VAB = "0*1000"
+            SAn = "3500*1000/3"
+            SAB = "3500*1000/3"
+            pf_modeA = "Lag"
+            pfA = "0"
+            VBn = "0*1000/(3**0.5)"
+            VBC = "0*1000"
+            SBn = "3500*1000/3"
+            SBC = "3500*1000/3"
+            pf_modeB = "Lag"
+            pfB = "0"
+            VCn = "0*1000/(3**0.5)"
+            VCA = "0*1000"
+            SCn = "3500*1000/3"
+            SCA = "3500*1000/3"
+            pf_modeC = "Lag"
+            pfC = "0"
+            kV = "0"
+            model = "2"
+            phases = "3"
+            phs = "0"
+            ph_num = "0"
+            pf = "0"
+            conn = "0"
+            kVA = "0"
+            basefreq = "0"
+            dss_mod = "Constant Impedance"
         }
 
         "core/Current Measurement" {
+            signal_access = "inherit"
             bw_limit = "False"
             frequency = "10e3"
             comparator_enable = "False"
@@ -31851,9 +29027,9 @@ if (counter >= Ts) {
             signal_name = ""
         }
 
-        "core/Edge Detection" {
-            edge = "both"
-            execution_rate = "inherit"
+        "core/Grid Fault" {
+            resistance = "0.0"
+            fault_type = "A-GND"
         }
 
         "core/Meter Split" {
@@ -31864,6 +29040,8 @@ if (counter >= Ts) {
             vbn_rms = "False"
             vcn_rms = "False"
             vln_rms = "False"
+            vn = "False"
+            vn_rms = "False"
             vab = "False"
             vbc = "False"
             vca = "False"
@@ -31878,6 +29056,8 @@ if (counter >= Ts) {
             ib_rms = "False"
             ic_rms = "False"
             i_rms = "False"
+            ineutral = "False"
+            in_rms = "False"
             freq = "False"
             power_p = "False"
             power_q = "False"
@@ -31982,26 +29162,6 @@ if (counter >= Ts) {
             ratio_110 = "0.1"
         }
 
-        "core/Single phase PLL" {
-            scheduling_mode = "Enable"
-            offset_Hz = "55"
-            delta_Hz_max = "10"
-            vd_init = "200"
-            angle_init = "0"
-            k_SOGI = "0.4"
-            kp_PLL_LOW = "4.81e3"
-            kp_PLL_HIGH = "527"
-            ki_PLL_LOW = "1.84e4"
-            ki_PLL_HIGH = "2.22e3"
-            kd_PLL_LOW = "-5.19"
-            kd_PLL_HIGH = "-0.519"
-            Tf_kd_PLL = "0.00108"
-            fc_LPF_vd = "20"
-            fc_LPF_wPLL = "100"
-            fc_LPF_fPLL = "10"
-            execution_rate = "inherit"
-        }
-
         "core/Three Phase Two Winding Transformer" {
             input = "SC and OC tests"
             Sn = "160000.0"
@@ -32054,22 +29214,28 @@ if (counter >= Ts) {
             enable_probes = "True"
             enable_out = "True"
             remove_snubber = "False"
+            enable_bandwidth = "False"
+            bandwidth = "10e3"
             VAn = "True"
             VBn = "True"
             VCn = "True"
             VAB = "False"
             VBC = "False"
             VCA = "False"
+            VN = "False"
             IA = "True"
             IB = "True"
             IC = "True"
+            IN = "False"
             freq = "False"
             VLn_rms = "False"
             VLL_rms = "False"
             VLn_avg_rms = "False"
             VLL_avg_rms = "False"
+            VN_rms = "False"
             I_rms = "False"
             I_avg_rms = "False"
+            IN_rms = "False"
             P_method = "alpha-beta"
             enable_extra_out = "False"
             P_meas = "False"
@@ -32080,6 +29246,7 @@ if (counter >= Ts) {
             num_of_phases = "3"
             model_def = "Geometry"
             unit_sys = "imperial"
+            unit_sys_edited_flag = "0"
             Length_metric = "100.0"
             Length_miles = "62.1371"
             Frequency = "60.0"
@@ -32141,6 +29308,7 @@ if (counter >= Ts) {
         }
 
         "core/Triple Pole Single Throw Contactor" {
+            signal_access = "inherit"
             ctrl_src = "Digital input"
             Sa = "1"
             Sa_logic = "active high"
@@ -32153,6 +29321,7 @@ if (counter >= Ts) {
         }
 
         "core/Voltage Measurement" {
+            signal_access = "inherit"
             bw_limit = "False"
             frequency = "10e3"
             comparator_enable = "False"
@@ -32173,15 +29342,6 @@ if (counter >= Ts) {
             visible = "True"
             override_signal_name = "False"
             signal_name = ""
-        }
-
-        "core/Voltage RMS" {
-            op_mode = "PLL based"
-            frequency = "50"
-            sig_output = "False"
-            execution_rate = "inherit"
-            feed_forward = "False"
-            nd_msr_estimation = "false"
         }
 
         "core/abc to dq" {

--- a/tse_to_opendss/thcc_libs/opendss_lib.tlib
+++ b/tse_to_opendss/thcc_libs/opendss_lib.tlib
@@ -18,6 +18,7 @@ library "OpenDSS" {
         device_ao_limit_enable = False
         reset_analog_outputs_on_sim_stop = True
         reset_digital_outputs_on_sim_stop = True
+        vhil_adio_loopback = False
         cpl_stb = False
         enb_dep_sw_detect = False
         code_section = "internal memory"
@@ -33,6 +34,7 @@ library "OpenDSS" {
         cpl_dynamics_analysis = False
         export_ss_to_pickle = False
         ground_scope_core = False
+        dss_num_tol = 1e-15
         cce_platform = "generic"
         cce_use_relative_names = False
         cce_type_mapping_real = "double"
@@ -43,14 +45,40 @@ library "OpenDSS" {
         cce_custom_type_uint = ""
         cce_custom_type_real = ""
         tunable_params = "component defined"
+        sp_compiler_type = "C compiler"
+        sig_stim = "off"
+        export_resource_list = ""
+        export_dependency_list = ""
+        excluded_resource_list = ""
+        export_out_file = ""
+        export_lock_top_level = True
+        export_encrypt_library = True
+        export_encrypt_resources = True
     }
 
     component Subsystem Root {
         component Subsystem Bus {
             layout = static
+            component "core/Open Circuit" vAB_RMS {
+            }
+            [
+                position = 7568, 8200
+            ]
+
+            component "core/Open Circuit" vBC_RMS {
+            }
+            [
+                position = 7680, 8200
+            ]
+
+            component "core/Open Circuit" vCA_RMS {
+            }
+            [
+                position = 7624, 8400
+                scale = -1, 1
+            ]
 
             port A1 {
-                label = "A1"
                 position = -8.0, -32.0
                 kind = pe
                 direction =  in
@@ -59,8 +87,17 @@ library "OpenDSS" {
                 position = 7400, 7856
             ]
 
+            port A2 {
+                position = 8.0, -32.0
+                kind = pe
+                direction =  in
+            }
+            [
+                position = 7904, 7856
+                rotation = down
+            ]
+
             port B1 {
-                label = "B1"
                 position = -8.0, 0
                 kind = pe
                 direction =  in
@@ -69,8 +106,17 @@ library "OpenDSS" {
                 position = 7400, 7952
             ]
 
+            port B2 {
+                position = 8.0, 0
+                kind = pe
+                direction =  in
+            }
+            [
+                position = 7904, 7952
+                rotation = down
+            ]
+
             port C1 {
-                label = "C1"
                 position = -8.0, 32.0
                 kind = pe
                 direction =  in
@@ -79,37 +125,14 @@ library "OpenDSS" {
                 position = 7400, 8048
             ]
 
-            port A2 {
-                label = "A2"
-                position = 8.0, -32.0
-                kind = pe
-                direction =  in
-            }
-            [
-                position = 7900, 7856
-                scale = -1, 1
-            ]
-
-            port B2 {
-                label = "B2"
-                position = 8.0, 0
-                kind = pe
-                direction =  in
-            }
-            [
-                position = 7900, 7952
-                scale = -1, 1
-            ]
-
             port C2 {
-                label = "C2"
                 position = 8.0, 32.0
                 kind = pe
                 direction =  in
             }
             [
-                position = 7900, 8048
-                scale = -1, 1
+                position = 7904, 8048
+                rotation = down
             ]
 
             junction Aj pe
@@ -129,17 +152,17 @@ library "OpenDSS" {
 
             junction A_imeas_j pe
             [
-                position = 7850, 7856
+                position = 7848, 7856
             ]
 
             junction B_imeas_j pe
             [
-                position = 7850, 7952
+                position = 7848, 7952
             ]
 
             junction C_imeas_j pe
             [
-                position = 7850, 8048
+                position = 7848, 8048
             ]
 
             junction jA_vmeas pe
@@ -157,12 +180,21 @@ library "OpenDSS" {
                 position = 7744, 8200
             ]
 
-            connect A1 Aj as conn_A1Aj
-            connect B1 Bj as conn_B1Bj
-            connect C1 Cj as conn_C1Cj
-            connect A2 A_imeas_j as conn_A2Aj
-            connect B2 B_imeas_j as conn_B2Bj
-            connect C2 C_imeas_j as conn_C2Cj
+            connect A1 Aj as Connection1
+            connect A2 A_imeas_j as Connection2
+            connect B1 Bj as Connection3
+            connect B2 B_imeas_j as Connection4
+            connect C1 Cj as Connection5
+            connect C2 C_imeas_j as Connection6
+            connect Aj jA_vmeas as verticalA
+            connect Bj jAB_vmeas as verticalB
+            connect Cj jB_vmeas as verticalC
+            connect vAB_RMS.p_node jA_vmeas as Connection7
+            connect vAB_RMS.n_node jAB_vmeas as Connection8
+            connect vBC_RMS.p_node jAB_vmeas as Connection9
+            connect vBC_RMS.n_node jB_vmeas as Connection10
+            connect vCA_RMS.p_node jB_vmeas as Connection11
+            connect vCA_RMS.n_node jA_vmeas as Connection12
             connect Aj A_imeas_j as sc_imeas_A
             connect Bj B_imeas_j as sc_imeas_B
             connect Cj C_imeas_j as sc_imeas_C
@@ -329,7 +361,7 @@ library "OpenDSS" {
             ]
 
             port A1 {
-                position = -32.0, -32.0
+                position = -32, -32
                 kind = pe
             }
             [
@@ -337,7 +369,7 @@ library "OpenDSS" {
             ]
 
             port B1 {
-                position = -32.0, 0.0
+                position = -32, 0
                 kind = pe
             }
             [
@@ -345,7 +377,7 @@ library "OpenDSS" {
             ]
 
             port C1 {
-                position = -32.0, 32.0
+                position = -32, 32
                 kind = pe
             }
             [
@@ -353,7 +385,7 @@ library "OpenDSS" {
             ]
 
             port A2 {
-                position = 32.0, -32.0
+                position = 32, -32
                 kind = pe
             }
             [
@@ -362,7 +394,7 @@ library "OpenDSS" {
             ]
 
             port B2 {
-                position = 32.0, 0.0
+                position = 32, 0
                 kind = pe
             }
             [
@@ -371,7 +403,7 @@ library "OpenDSS" {
             ]
 
             port C2 {
-                position = 32.0, 32.0
+                position = 32, 32
                 kind = pe
             }
             [
@@ -387,13 +419,13 @@ library "OpenDSS" {
                 position = 7728, 8144
             ]
 
-            connect N TL.gnd as ConnTLN1
             connect A1 TL.a_in as Connection1
             connect B1 TL.b_in as Connection2
             connect C1 TL.c_in as Connection3
             connect A2 TL.a_out as Connection4
             connect B2 TL.b_out as Connection5
             connect C2 TL.c_out as Connection6
+            connect TL.gnd N as Connection7
 
             mask {
                 description = "<html><head><meta name=\"qrichtext\" content=\"1\"></meta><style type=\"text/css\">p, li { white-space: pre-wrap; }</style></head><body style=\"\"><p style=\"margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">Line component.</p></body></html>"
@@ -474,8 +506,8 @@ library "OpenDSS" {
                     widget = checkbox
                     type = bool
                     default_value = "True"
-                    no_evaluate
                     group = "Line Parameters"
+                    no_evaluate
 
                     CODE property_value_edited
                         comp_script = return_comp_script(mdl, container_handle)
@@ -752,6 +784,7 @@ library "OpenDSS" {
                     type = bool
                     default_value = "False"
                     group = "Monitoring"
+                    no_evaluate
                 }
 
                 CODE open
@@ -897,7 +930,7 @@ library "OpenDSS" {
                 size = 48, 80
             ]
 
-            component src_constant Constant3 {
+            component "core/Constant" Constant3 {
                 execution_rate = "Ts"
                 value = "0"
             }
@@ -915,14 +948,14 @@ library "OpenDSS" {
                 size = 48, 80
             ]
 
-            component gen_product Product1 {
+            component "core/Product" Product1 {
             }
             [
                 position = 10296, 8792
                 hide_name = True
             ]
 
-            component gen_gain Gain9 {
+            component "core/Gain" Gain9 {
                 gain = "1.5"
             }
             [
@@ -930,24 +963,23 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_probe P_gen {
+            component "core/Probe" P_gen {
                 signal_name = "P"
-                signal_type = "power"
-                streaming_en = "False"
+                signal_type = "active power"
             }
             [
                 position = 10496, 8752
                 rotation = left
             ]
 
-            component gen_product Product4 {
+            component "core/Product" Product4 {
             }
             [
                 position = 10296, 8896
                 hide_name = True
             ]
 
-            component gen_gain Gain10 {
+            component "core/Gain" Gain10 {
                 gain = "-1.5"
             }
             [
@@ -955,17 +987,16 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_probe Q_gen {
+            component "core/Probe" Q_gen {
                 signal_name = "Q"
-                signal_type = "power"
-                streaming_en = "False"
+                signal_type = "active power"
             }
             [
                 position = 10496, 8856
                 rotation = left
             ]
 
-            component gen_sum Sum7 {
+            component "core/Sum" Sum7 {
                 signs = "+-"
             }
             [
@@ -973,7 +1004,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_integrator Integrator3 {
+            component "core/Integrator" Integrator3 {
                 limit_lower = "-1000*vdc_set*0.05"
                 limit_output = "True"
                 limit_upper = "1000*vdc_set*0.05"
@@ -983,7 +1014,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_sum Sum8 {
+            component "core/Sum" Sum8 {
                 signs = "++"
             }
             [
@@ -991,7 +1022,8 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch3" {
+            component "core/Signal switch" "Signal switch3" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -999,7 +1031,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component src_constant Constant4 {
+            component "core/Constant" Constant4 {
                 execution_rate = "Ts"
                 value = "0"
             }
@@ -1009,7 +1041,8 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch4" {
+            component "core/Signal switch" "Signal switch4" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -1017,7 +1050,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_sum Sum9 {
+            component "core/Sum" Sum9 {
                 signs = "+-"
             }
             [
@@ -1025,7 +1058,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_integrator Integrator4 {
+            component "core/Integrator" Integrator4 {
                 limit_lower = "-1000*vdc_set*0.05"
                 limit_output = "True"
                 limit_upper = "1000*vdc_set*0.05"
@@ -1035,7 +1068,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_gain Gain13 {
+            component "core/Gain" Gain13 {
                 gain = "P_ki"
             }
             [
@@ -1043,7 +1076,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_gain Gain14 {
+            component "core/Gain" Gain14 {
                 gain = "P_kp"
             }
             [
@@ -1051,7 +1084,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_sum Sum10 {
+            component "core/Sum" Sum10 {
                 signs = "++"
             }
             [
@@ -1059,7 +1092,8 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch5" {
+            component "core/Signal switch" "Signal switch5" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -1067,7 +1101,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component src_constant Constant5 {
+            component "core/Constant" Constant5 {
                 execution_rate = "Ts"
                 value = "0"
             }
@@ -1077,7 +1111,8 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch6" {
+            component "core/Signal switch" "Signal switch6" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -1085,7 +1120,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_sum Sum11 {
+            component "core/Sum" Sum11 {
                 signs = "+-"
             }
             [
@@ -1093,16 +1128,15 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_probe V_gen {
+            component "core/Probe" V_gen {
                 signal_name = "V"
                 signal_type = "voltage"
-                streaming_en = "False"
             }
             [
                 position = 7872, 8064
             ]
 
-            component gen_gain Gain21 {
+            component "core/Gain" Gain21 {
                 gain = "0.001"
             }
             [
@@ -1110,7 +1144,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_gain Gain22 {
+            component "core/Gain" Gain22 {
                 gain = "0.001"
             }
             [
@@ -1118,7 +1152,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_gain Gain23 {
+            component "core/Gain" Gain23 {
                 gain = "1.224745"
             }
             [
@@ -1126,7 +1160,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component src_constant Constant9 {
+            component "core/Constant" Constant9 {
                 execution_rate = "Ts"
                 value = "ext_mode"
             }
@@ -1135,7 +1169,8 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch12" {
+            component "core/Signal switch" "Signal switch12" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -1143,7 +1178,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_gain Gain24 {
+            component "core/Gain" Gain24 {
                 gain = "Q_kp"
             }
             [
@@ -1151,7 +1186,8 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch13" {
+            component "core/Signal switch" "Signal switch13" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -1159,7 +1195,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_gain Gain25 {
+            component "core/Gain" Gain25 {
                 gain = "V_kp"
             }
             [
@@ -1167,7 +1203,8 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch14" {
+            component "core/Signal switch" "Signal switch14" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -1175,7 +1212,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_gain Gain26 {
+            component "core/Gain" Gain26 {
                 gain = "Q_ki"
             }
             [
@@ -1183,7 +1220,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_gain Gain27 {
+            component "core/Gain" Gain27 {
                 gain = "V_ki"
             }
             [
@@ -1191,7 +1228,7 @@ library "OpenDSS" {
                 hide_name = True
             ]
 
-            component gen_c_function "C function1" {
+            component "core/C function" "C function1" {
                 input_terminals = "real mode_external;inherit Mode_select_ext;inherit Mode_select_int;"
                 input_terminals_dimensions = "inherit;inherit;inherit"
                 input_terminals_feedthrough = "True;True;True"
@@ -1273,7 +1310,7 @@ else {
                 size = 192, 96
             ]
 
-            component src_constant Constant13 {
+            component "core/Constant" Constant13 {
                 execution_rate = "Ts"
                 value = "ctrl_mode_int"
             }
@@ -1282,7 +1319,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_gain Gain28 {
+            component "core/Gain" Gain28 {
                 gain = "vdc_kp"
             }
             [
@@ -1290,7 +1327,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_gain Gain29 {
+            component "core/Gain" Gain29 {
                 gain = "vdc_ki"
             }
             [
@@ -1298,7 +1335,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_sum Sum14 {
+            component "core/Sum" Sum14 {
                 signs = "+-"
             }
             [
@@ -1306,7 +1343,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_gain Gain30 {
+            component "core/Gain" Gain30 {
                 gain = "1000"
             }
             [
@@ -1314,7 +1351,8 @@ else {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch15" {
+            component "core/Signal switch" "Signal switch15" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -1322,7 +1360,8 @@ else {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch16" {
+            component "core/Signal switch" "Signal switch16" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -1330,7 +1369,8 @@ else {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch17" {
+            component "core/Signal switch" "Signal switch17" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -1338,7 +1378,7 @@ else {
                 hide_name = True
             ]
 
-            component src_constant Constant14 {
+            component "core/Constant" Constant14 {
                 execution_rate = "Ts"
             }
             [
@@ -1346,7 +1386,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_gain Gain32 {
+            component "core/Gain" Gain32 {
             }
             [
                 position = 7184, 9200
@@ -1380,42 +1420,42 @@ else {
                 size = 64, 32
             ]
 
-            component pas_resistor Ra {
+            component "core/Resistor" Ra {
                 resistance = "Rac"
             }
             [
                 position = 8560, 9424
             ]
 
-            component pas_resistor Rb {
+            component "core/Resistor" Rb {
                 resistance = "Rac"
             }
             [
                 position = 8560, 9504
             ]
 
-            component pas_resistor Rc {
+            component "core/Resistor" Rc {
                 resistance = "Rac"
             }
             [
                 position = 8560, 9584
             ]
 
-            component pas_inductor La {
+            component "core/Inductor" La {
                 inductance = "Lac"
             }
             [
                 position = 8688, 9424
             ]
 
-            component pas_inductor Lb {
+            component "core/Inductor" Lb {
                 inductance = "Lac"
             }
             [
                 position = 8688, 9504
             ]
 
-            component pas_inductor Lc {
+            component "core/Inductor" Lc {
                 inductance = "Lac"
             }
             [
@@ -1479,7 +1519,7 @@ else {
                 size = 64, 32
             ]
 
-            component gen_sum Sum15 {
+            component "core/Sum" Sum15 {
                 signs = "+-"
             }
             [
@@ -1487,7 +1527,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_sum Sum16 {
+            component "core/Sum" Sum16 {
                 signs = "+-"
             }
             [
@@ -1495,7 +1535,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_sum Sum17 {
+            component "core/Sum" Sum17 {
                 signs = "+-"
             }
             [
@@ -1503,28 +1543,25 @@ else {
                 hide_name = True
             ]
 
-            component gen_probe Vab {
+            component "core/Probe" Vab {
                 signal_name = "V"
                 signal_type = "voltage"
-                streaming_en = "False"
             }
             [
                 position = 10384, 8488
             ]
 
-            component gen_probe Vbc {
+            component "core/Probe" Vbc {
                 signal_name = "V"
                 signal_type = "voltage"
-                streaming_en = "False"
             }
             [
                 position = 10384, 8592
             ]
 
-            component gen_probe Vca {
+            component "core/Probe" Vca {
                 signal_name = "V"
                 signal_type = "voltage"
-                streaming_en = "False"
             }
             [
                 position = 10384, 8696
@@ -1532,21 +1569,21 @@ else {
 
             component Subsystem Subsystem8 {
                 layout = dynamic
-                component gen_product Product5 {
+                component "core/Product" Product5 {
                 }
                 [
                     position = 8080, 7888
                     hide_name = True
                 ]
 
-                component gen_sum Sum16 {
+                component "core/Sum" Sum16 {
                 }
                 [
                     position = 8160, 7920
                     hide_name = True
                 ]
 
-                component gen_math_fnc "Mathematical function2" {
+                component "core/Mathematical function" "Mathematical function2" {
                     mathematical_fn = "sqrt"
                 }
                 [
@@ -1554,14 +1591,14 @@ else {
                     hide_name = True
                 ]
 
-                component gen_product Product4 {
+                component "core/Product" Product4 {
                 }
                 [
                     position = 8080, 7968
                     hide_name = True
                 ]
 
-                component gen_trigonometric "Trigonometric function4" {
+                component "core/Trigonometric function" "Trigonometric function4" {
                     trigonometric_fn = "asin"
                 }
                 [
@@ -1569,7 +1606,7 @@ else {
                     hide_name = True
                 ]
 
-                component gen_product Product7 {
+                component "core/Product" Product7 {
                     signs = "*/"
                 }
                 [
@@ -1577,14 +1614,14 @@ else {
                     hide_name = True
                 ]
 
-                component gen_rel_op "Relational operator2" {
+                component "core/Relational operator" "Relational operator2" {
                 }
                 [
                     position = 8344, 7992
                     hide_name = True
                 ]
 
-                component src_constant Constant5 {
+                component "core/Constant" Constant5 {
                     execution_rate = "Ts"
                     value = "0"
                 }
@@ -1593,7 +1630,8 @@ else {
                     hide_name = True
                 ]
 
-                component sys_signal_switch "Signal switch4" {
+                component "core/Signal switch" "Signal switch4" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
@@ -1601,7 +1639,8 @@ else {
                     hide_name = True
                 ]
 
-                component sys_signal_switch "Signal switch12" {
+                component "core/Signal switch" "Signal switch12" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
@@ -1609,14 +1648,14 @@ else {
                     hide_name = True
                 ]
 
-                component gen_sum Sum19 {
+                component "core/Sum" Sum19 {
                 }
                 [
                     position = 8232, 8072
                     hide_name = True
                 ]
 
-                component src_constant Constant6 {
+                component "core/Constant" Constant6 {
                     execution_rate = "Ts"
                     value = "0.001"
                 }
@@ -1625,7 +1664,7 @@ else {
                     hide_name = True
                 ]
 
-                component src_constant Constant7 {
+                component "core/Constant" Constant7 {
                     execution_rate = "Ts"
                     value = "0"
                 }
@@ -1634,14 +1673,15 @@ else {
                     hide_name = True
                 ]
 
-                component gen_comparator Comparator4 {
+                component "core/Comparator" Comparator4 {
                 }
                 [
                     position = 8264, 8160
                     hide_name = True
                 ]
 
-                component sys_signal_switch "Signal switch13" {
+                component "core/Signal switch" "Signal switch13" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
@@ -1649,7 +1689,7 @@ else {
                     hide_name = True
                 ]
 
-                component gen_sum Sum20 {
+                component "core/Sum" Sum20 {
                     signs = "+-"
                 }
                 [
@@ -1657,7 +1697,7 @@ else {
                     hide_name = True
                 ]
 
-                component src_constant Constant8 {
+                component "core/Constant" Constant8 {
                     execution_rate = "Ts"
                     value = "np.pi"
                 }
@@ -1666,14 +1706,15 @@ else {
                     hide_name = True
                 ]
 
-                component gen_comparator Comparator5 {
+                component "core/Comparator" Comparator5 {
                 }
                 [
                     position = 9008, 8312
                     hide_name = True
                 ]
 
-                component sys_signal_switch "Signal switch14" {
+                component "core/Signal switch" "Signal switch14" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
@@ -1681,7 +1722,7 @@ else {
                     hide_name = True
                 ]
 
-                component gen_sum Sum21 {
+                component "core/Sum" Sum21 {
                     signs = "+-"
                 }
                 [
@@ -1689,7 +1730,7 @@ else {
                     hide_name = True
                 ]
 
-                component src_constant Constant9 {
+                component "core/Constant" Constant9 {
                     execution_rate = "Ts"
                     value = "-np.pi"
                 }
@@ -1698,7 +1739,7 @@ else {
                     hide_name = True
                 ]
 
-                component src_constant Constant10 {
+                component "core/Constant" Constant10 {
                     execution_rate = "Ts"
                     value = "0"
                 }
@@ -1897,14 +1938,14 @@ else {
                 size = 48, 64
             ]
 
-            component gen_comparator Comparator1 {
+            component "core/Comparator" Comparator1 {
             }
             [
                 position = 8224, 8264
                 hide_name = True
             ]
 
-            component src_clock Clock1 {
+            component "core/Clock" Clock1 {
                 execution_rate = "Ts"
             }
             [
@@ -1912,7 +1953,7 @@ else {
                 hide_name = True
             ]
 
-            component src_constant Constant21 {
+            component "core/Constant" Constant21 {
                 execution_rate = "Ts"
                 value = "cont_t"
             }
@@ -1921,7 +1962,7 @@ else {
                 hide_name = True
             ]
 
-            component src_constant Constant22 {
+            component "core/Constant" Constant22 {
                 execution_rate = "Ts"
                 value = "Sinv"
             }
@@ -1930,7 +1971,7 @@ else {
                 hide_name = True
             ]
 
-            component src_constant Constant23 {
+            component "core/Constant" Constant23 {
                 execution_rate = "Ts"
                 value = "Qinv"
             }
@@ -1939,7 +1980,7 @@ else {
                 hide_name = True
             ]
 
-            component src_constant Constant24 {
+            component "core/Constant" Constant24 {
                 execution_rate = "Ts"
                 value = "Fs"
             }
@@ -1948,7 +1989,7 @@ else {
                 hide_name = True
             ]
 
-            component src_constant Constant25 {
+            component "core/Constant" Constant25 {
                 execution_rate = "Ts"
                 value = "vac_set"
             }
@@ -1965,7 +2006,7 @@ else {
                 size = 48, 80
             ]
 
-            component src_constant Constant27 {
+            component "core/Constant" Constant27 {
                 execution_rate = "Ts"
                 value = "0"
             }
@@ -1975,7 +2016,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_gain Gain33 {
+            component "core/Gain" Gain33 {
                 gain = "2*np.pi"
             }
             [
@@ -1983,7 +2024,7 @@ else {
                 hide_name = True
             ]
 
-            component src_constant Constant28 {
+            component "core/Constant" Constant28 {
                 execution_rate = "Ts"
                 value = "2*np.pi"
             }
@@ -1993,7 +2034,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_c_function "C function2" {
+            component "core/C function" "C function2" {
                 global_variables = "real out_mem;"
                 init_fnc = "/*Begin code section*/
 out_mem = ang_init;
@@ -2020,7 +2061,7 @@ out_mem = out;
                 size = 112, 80
             ]
 
-            component src_constant Constant30 {
+            component "core/Constant" Constant30 {
                 execution_rate = "Ts"
                 value = "Ts"
             }
@@ -2030,7 +2071,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component gen_sum Sum19 {
+            component "core/Sum" Sum19 {
                 signs = "++"
             }
             [
@@ -2038,7 +2079,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component src_constant Constant31 {
+            component "core/Constant" Constant31 {
                 execution_rate = "Ts"
                 value = "Ts*Fs*2*np.pi"
             }
@@ -2047,7 +2088,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component gen_sum Sum23 {
+            component "core/Sum" Sum23 {
                 signs = "++"
             }
             [
@@ -2055,7 +2096,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component gen_limiter Limit1 {
+            component "core/Limit" Limit1 {
                 lower_limit = "-1000*vdc_set*0.05"
                 upper_limit = "1000*vdc_set*0.05"
             }
@@ -2064,7 +2105,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component gen_limiter Limit2 {
+            component "core/Limit" Limit2 {
                 lower_limit = "-1000*vdc_set*0.05"
                 upper_limit = "1000*vdc_set*0.05"
             }
@@ -2073,7 +2114,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component gen_sum Sum24 {
+            component "core/Sum" Sum24 {
                 signs = "+"
             }
             [
@@ -2081,7 +2122,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component gen_sum Sum25 {
+            component "core/Sum" Sum25 {
                 signs = "++"
             }
             [
@@ -2089,7 +2130,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component gen_sum Sum26 {
+            component "core/Sum" Sum26 {
                 signs = "+-"
             }
             [
@@ -2097,7 +2138,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component src_constant Constant38 {
+            component "core/Constant" Constant38 {
                 execution_rate = "Ts"
                 value = "0"
             }
@@ -2106,7 +2147,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component gen_rate_limiter "Rate Limiter1" {
+            component "core/Rate Limiter" "Rate Limiter1" {
                 falling_limit = "-1*Sinv*Fs*1000"
                 rising_limit = "1*Sinv*Fs*1000"
             }
@@ -2116,7 +2157,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component gen_sum Sum27 {
+            component "core/Sum" Sum27 {
                 signs = "+-"
             }
             [
@@ -2124,7 +2165,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component src_constant Constant39 {
+            component "core/Constant" Constant39 {
                 execution_rate = "Ts"
                 value = "0"
             }
@@ -2133,7 +2174,7 @@ out_mem = out;
                 hide_name = True
             ]
 
-            component gen_rate_limiter "Rate Limiter4" {
+            component "core/Rate Limiter" "Rate Limiter4" {
                 falling_limit = "-1*Sinv*Fs*1000"
                 rising_limit = "1*Sinv*Fs*1000"
             }
@@ -2151,7 +2192,7 @@ out_mem = out;
                 size = 64, 32
             ]
 
-            component gen_c_function "C function3" {
+            component "core/C function" "C function3" {
                 global_variables = "real ia_add;real ib_add;real ic_add;real ia_addn;real ib_addn;real ic_addn;real idcp;real idcn;real Emax;real Z;real VLL;real con_mode;"
                 init_fnc = "/*Begin code section*/
 Z = sqrt(Rac*Rac+Fs*Fs*4*Lac*Lac*9.8696);
@@ -2342,20 +2383,18 @@ if (Vdc<-2) {
                 size = 64, 32
             ]
 
-            component gen_probe DC_C {
+            component "core/Probe" DC_C {
                 signal_name = "V"
                 signal_type = "current"
-                streaming_en = "False"
             }
             [
                 position = 9920, 8560
                 rotation = left
             ]
 
-            component gen_probe DC_VDC {
+            component "core/Probe" DC_VDC {
                 signal_name = "V"
                 signal_type = "voltage"
-                streaming_en = "False"
             }
             [
                 position = 8056, 9568
@@ -2363,21 +2402,21 @@ if (Vdc<-2) {
 
             component Subsystem Subsystem9 {
                 layout = dynamic
-                component gen_product Product5 {
+                component "core/Product" Product5 {
                 }
                 [
                     position = 8080, 7888
                     hide_name = True
                 ]
 
-                component gen_sum Sum16 {
+                component "core/Sum" Sum16 {
                 }
                 [
                     position = 8160, 7920
                     hide_name = True
                 ]
 
-                component gen_math_fnc "Mathematical function2" {
+                component "core/Mathematical function" "Mathematical function2" {
                     mathematical_fn = "sqrt"
                 }
                 [
@@ -2385,14 +2424,14 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component gen_product Product4 {
+                component "core/Product" Product4 {
                 }
                 [
                     position = 8080, 7968
                     hide_name = True
                 ]
 
-                component gen_trigonometric "Trigonometric function4" {
+                component "core/Trigonometric function" "Trigonometric function4" {
                     trigonometric_fn = "asin"
                 }
                 [
@@ -2400,7 +2439,7 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component gen_product Product7 {
+                component "core/Product" Product7 {
                     signs = "*/"
                 }
                 [
@@ -2408,14 +2447,14 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component gen_rel_op "Relational operator2" {
+                component "core/Relational operator" "Relational operator2" {
                 }
                 [
                     position = 8344, 7992
                     hide_name = True
                 ]
 
-                component src_constant Constant5 {
+                component "core/Constant" Constant5 {
                     execution_rate = "Ts"
                     value = "0"
                 }
@@ -2424,7 +2463,8 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component sys_signal_switch "Signal switch4" {
+                component "core/Signal switch" "Signal switch4" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
@@ -2432,7 +2472,8 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component sys_signal_switch "Signal switch12" {
+                component "core/Signal switch" "Signal switch12" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
@@ -2440,14 +2481,14 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component gen_sum Sum19 {
+                component "core/Sum" Sum19 {
                 }
                 [
                     position = 8232, 8072
                     hide_name = True
                 ]
 
-                component src_constant Constant6 {
+                component "core/Constant" Constant6 {
                     execution_rate = "Ts"
                     value = "0.001"
                 }
@@ -2456,7 +2497,7 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component src_constant Constant7 {
+                component "core/Constant" Constant7 {
                     execution_rate = "Ts"
                     value = "0"
                 }
@@ -2465,14 +2506,15 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component gen_comparator Comparator4 {
+                component "core/Comparator" Comparator4 {
                 }
                 [
                     position = 8264, 8160
                     hide_name = True
                 ]
 
-                component sys_signal_switch "Signal switch13" {
+                component "core/Signal switch" "Signal switch13" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
@@ -2480,7 +2522,7 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component gen_sum Sum20 {
+                component "core/Sum" Sum20 {
                     signs = "+-"
                 }
                 [
@@ -2488,7 +2530,7 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component src_constant Constant8 {
+                component "core/Constant" Constant8 {
                     execution_rate = "Ts"
                     value = "np.pi"
                 }
@@ -2497,14 +2539,15 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component gen_comparator Comparator5 {
+                component "core/Comparator" Comparator5 {
                 }
                 [
                     position = 9008, 8312
                     hide_name = True
                 ]
 
-                component sys_signal_switch "Signal switch14" {
+                component "core/Signal switch" "Signal switch14" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
@@ -2512,7 +2555,7 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component gen_sum Sum21 {
+                component "core/Sum" Sum21 {
                     signs = "+-"
                 }
                 [
@@ -2520,7 +2563,7 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component src_constant Constant9 {
+                component "core/Constant" Constant9 {
                     execution_rate = "Ts"
                     value = "-np.pi"
                 }
@@ -2529,7 +2572,7 @@ if (Vdc<-2) {
                     hide_name = True
                 ]
 
-                component src_constant Constant10 {
+                component "core/Constant" Constant10 {
                     execution_rate = "Ts"
                     value = "0"
                 }
@@ -2727,7 +2770,7 @@ if (Vdc<-2) {
                 size = 48, 64
             ]
 
-            component gen_limiter Limit3 {
+            component "core/Limit" Limit3 {
                 lower_limit = "0.1"
                 upper_limit = "1e9"
             }
@@ -2736,7 +2779,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_product Product12 {
+            component "core/Product" Product12 {
                 signs = "*/"
             }
             [
@@ -2744,7 +2787,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_limiter Limit4 {
+            component "core/Limit" Limit4 {
                 lower_limit = "0.1"
                 upper_limit = "1e9"
             }
@@ -2753,7 +2796,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_limiter Limit5 {
+            component "core/Limit" Limit5 {
                 lower_limit = "0"
                 upper_limit = "1"
             }
@@ -2762,22 +2805,23 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_product Product13 {
+            component "core/Product" Product13 {
             }
             [
                 position = 8584, 8592
                 hide_name = True
             ]
 
-            component gen_product Product14 {
+            component "core/Product" Product14 {
             }
             [
                 position = 8600, 8792
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch18" {
-                threshold = "0.5"
+            component "core/Signal switch" "Signal switch18" {
+                criterion = "ctrl >= threshold"
+                    threshold = "0.5"
             }
             [
                 position = 8672, 8576
@@ -2785,15 +2829,16 @@ if (Vdc<-2) {
                 scale = 1, -1
             ]
 
-            component sys_signal_switch "Signal switch19" {
-                threshold = "0.5"
+            component "core/Signal switch" "Signal switch19" {
+                criterion = "ctrl >= threshold"
+                    threshold = "0.5"
             }
             [
                 position = 8704, 8808
                 hide_name = True
             ]
 
-            component gen_gain Gain35 {
+            component "core/Gain" Gain35 {
                 gain = "0.6366"
             }
             [
@@ -2801,7 +2846,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_product Product15 {
+            component "core/Product" Product15 {
                 signs = "*/"
             }
             [
@@ -2809,7 +2854,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_limiter Limit6 {
+            component "core/Limit" Limit6 {
                 lower_limit = "0"
                 upper_limit = "1"
             }
@@ -2818,7 +2863,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component src_constant Constant43 {
+            component "core/Constant" Constant43 {
                 execution_rate = "Ts"
             }
             [
@@ -2826,32 +2871,30 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_probe DC_m0 {
+            component "core/Probe" DC_m0 {
                 signal_name = "V"
-                streaming_en = "False"
             }
             [
                 position = 9736, 9056
                 rotation = right
             ]
 
-            component gen_product Product16 {
+            component "core/Product" Product16 {
             }
             [
                 position = 10296, 9008
                 hide_name = True
             ]
 
-            component gen_probe DC_Pow {
+            component "core/Probe" DC_Pow {
                 signal_name = "V"
-                signal_type = "power"
-                streaming_en = "False"
+                signal_type = "active power"
             }
             [
                 position = 10472, 9008
             ]
 
-            component gen_gain Gain36 {
+            component "core/Gain" Gain36 {
                 gain = "0.001"
             }
             [
@@ -2859,7 +2902,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component src_constant Constant44 {
+            component "core/Constant" Constant44 {
                 execution_rate = "Ts"
                 value = "vdc_set"
             }
@@ -2868,14 +2911,14 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain37 {
+            component "core/Gain" Gain37 {
             }
             [
                 position = 6288, 8472
                 hide_name = True
             ]
 
-            component gen_gain Gain38 {
+            component "core/Gain" Gain38 {
                 gain = "-1"
             }
             [
@@ -2884,7 +2927,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component pas_resistor R_SN {
+            component "core/Resistor" R_SN {
                 resistance = "dc_snub"
             }
             [
@@ -2892,7 +2935,7 @@ if (Vdc<-2) {
                 rotation = right
             ]
 
-            component gen_gain Gain39 {
+            component "core/Gain" Gain39 {
                 gain = "1000"
             }
             [
@@ -2900,7 +2943,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain40 {
+            component "core/Gain" Gain40 {
                 gain = "0.001"
             }
             [
@@ -2908,15 +2951,16 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch20" {
-                threshold = "0.5"
+            component "core/Signal switch" "Signal switch20" {
+                criterion = "ctrl >= threshold"
+                    threshold = "0.5"
             }
             [
                 position = 8472, 8248
                 hide_name = True
             ]
 
-            component src_constant Constant45 {
+            component "core/Constant" Constant45 {
                 execution_rate = "Ts"
                 value = "0"
             }
@@ -2925,7 +2969,8 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch21" {
+            component "core/Signal switch" "Signal switch21" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -2933,7 +2978,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component tm_delay "Unit Delay1" {
+            component "core/Unit Delay" "Unit Delay1" {
             }
             [
                 position = 9064, 8608
@@ -2941,7 +2986,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_terminator Termination100 {
+            component "core/Termination" Termination100 {
             }
             [
                 position = 9288, 9016
@@ -2949,7 +2994,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_terminator Termination101 {
+            component "core/Termination" Termination101 {
             }
             [
                 position = 7480, 8312
@@ -2957,7 +3002,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_terminator Termination102 {
+            component "core/Termination" Termination102 {
             }
             [
                 position = 8112, 8608
@@ -2965,7 +3010,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component pas_capacitor dccap {
+            component "core/Capacitor" dccap {
                 capacitance = "dc_cap"
                 initial_voltage = "1000*vdc_set"
             }
@@ -2974,7 +3019,7 @@ if (Vdc<-2) {
                 rotation = right
             ]
 
-            component gen_z_domain_transfer "Discrete Transfer Function1" {
+            component "core/Discrete Transfer Function" "Discrete Transfer Function1" {
                 a_coeff = "[.001,1]"
                 b_coeff = "[1]"
                 domain = "S-domain"
@@ -2985,7 +3030,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_sum Sum28 {
+            component "core/Sum" Sum28 {
                 signs = "+-"
             }
             [
@@ -2993,7 +3038,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component src_constant Constant47 {
+            component "core/Constant" Constant47 {
                 execution_rate = "Ts"
                 value = "vac_set"
             }
@@ -3002,7 +3047,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_sum Sum29 {
+            component "core/Sum" Sum29 {
                 signs = "++"
             }
             [
@@ -3010,7 +3055,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain42 {
+            component "core/Gain" Gain42 {
                 gain = "1000/1.224745"
             }
             [
@@ -3018,7 +3063,8 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch24" {
+            component "core/Signal switch" "Signal switch24" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -3028,27 +3074,27 @@ if (Vdc<-2) {
 
             component Subsystem TS_module {
                 layout = dynamic
-                component src_clock Clock1 {
+                component "core/Clock" Clock1 {
                     execution_rate = "Texec"
                 }
                 [
                     position = 6824, 8000
                 ]
 
-                component gen_probe d_rel {
+                component "core/Probe" d_rel {
                     signal_name = "Delay release"
                 }
                 [
                     position = 6928, 7936
                 ]
 
-                component gen_comparator Comparator1 {
+                component "core/Comparator" Comparator1 {
                 }
                 [
                     position = 6928, 8000
                 ]
 
-                component src_constant Constant1 {
+                component "core/Constant" Constant1 {
                     execution_rate = "Texec"
                     value = "Tdel"
                 }
@@ -3056,21 +3102,22 @@ if (Vdc<-2) {
                     position = 6824, 8064
                 ]
 
-                component sys_signal_switch "Signal switch1" {
+                component "core/Signal switch" "Signal switch1" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
                     position = 7008, 8144
                 ]
 
-                component src_constant Constant3 {
+                component "core/Constant" Constant3 {
                     execution_rate = "Texec"
                 }
                 [
                     position = 6840, 8128
                 ]
 
-                component gen_integrator Integrator1 {
+                component "core/Integrator" Integrator1 {
                     show_reset = "rising"
                     show_state = "True"
                 }
@@ -3078,7 +3125,7 @@ if (Vdc<-2) {
                     position = 7352, 8152
                 ]
 
-                component src_constant Constant4 {
+                component "core/Constant" Constant4 {
                     execution_rate = "Texec"
                     value = "Tmax"
                 }
@@ -3086,13 +3133,13 @@ if (Vdc<-2) {
                     position = 7152, 8304
                 ]
 
-                component gen_comparator Comparator2 {
+                component "core/Comparator" Comparator2 {
                 }
                 [
                     position = 7240, 8296
                 ]
 
-                component lut_1d "1D look-up table1" {
+                component "core/1D look-up table" "1D look-up table1" {
                     in_vec_x = "T_vecP"
                     out_vec_f_x = "P_vec1"
                 }
@@ -3100,7 +3147,7 @@ if (Vdc<-2) {
                     position = 7608, 8008
                 ]
 
-                component lut_1d "1D look-up table2" {
+                component "core/1D look-up table" "1D look-up table2" {
                     in_vec_x = "T_vecQ"
                     out_vec_f_x = "Q_vec1"
                 }
@@ -3108,7 +3155,7 @@ if (Vdc<-2) {
                     position = 7608, 8192
                 ]
 
-                component src_constant Constant5 {
+                component "core/Constant" Constant5 {
                     execution_rate = "Texec"
                     value = "0"
                 }
@@ -3116,14 +3163,15 @@ if (Vdc<-2) {
                     position = 6840, 8176
                 ]
 
-                component sys_signal_switch "Signal switch2" {
+                component "core/Signal switch" "Signal switch2" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
                     position = 7176, 8144
                 ]
 
-                component src_constant Constant6 {
+                component "core/Constant" Constant6 {
                     execution_rate = "Texec"
                     value = "loop_en"
                 }
@@ -3131,14 +3179,15 @@ if (Vdc<-2) {
                     position = 7112, 8048
                 ]
 
-                component sys_signal_switch "Signal switch3" {
+                component "core/Signal switch" "Signal switch3" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
                     position = 7456, 8160
                 ]
 
-                component src_constant Constant7 {
+                component "core/Constant" Constant7 {
                     execution_rate = "Texec"
                     value = "loop_en"
                 }
@@ -3146,7 +3195,7 @@ if (Vdc<-2) {
                     position = 7400, 8064
                 ]
 
-                component gen_gain Gain1 {
+                component "core/Gain" Gain1 {
                 }
                 [
                     position = 7384, 8352
@@ -3530,20 +3579,21 @@ if (Vdc<-2) {
 
             component Subsystem T_switch {
                 layout = dynamic
-                component sys_signal_switch "Signal switch1" {
+                component "core/Signal switch" "Signal switch1" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
                     position = 7632, 8056
                 ]
 
-                component gen_round Round1 {
+                component "core/Round" Round1 {
                 }
                 [
                     position = 7392, 8072
                 ]
 
-                component gen_limiter Limit1 {
+                component "core/Limit" Limit1 {
                     lower_limit = "T_lim_low"
                     upper_limit = "T_lim_high"
                 }
@@ -3620,7 +3670,7 @@ if (Vdc<-2) {
                 size = 72, 64
             ]
 
-            component src_constant Constant102 {
+            component "core/Constant" Constant102 {
                 execution_rate = "Ts"
                 value = "Ts_switch"
             }
@@ -5451,11 +5501,10 @@ if (Vdc<-2) {
             connect Gain32.in From25 as connmode
             connect Sum9.in From11 as connP
             connect Sum7.in From10 as connQ
-            connect Constant22.out Goto10 as connPint
             connect Sum11.in From15 as connV
-            connect Constant23.out Goto11 as connQint
             connect Gain30.in From22 as connw
             connect Gain33.in From44 as connfs
+            connect Constant22.out Goto10 as connPint
 
             loadshape = "[0.5, 0.8, 1, 0.4, 0.5]"
             loadshape_int = "1"
@@ -6379,6 +6428,7 @@ if (Vdc<-2) {
                     default_value = "Daily"
                     group = "Time Series"
                     nonvisible
+                    no_evaluate
                 }
 
                 T_Ts_internal {
@@ -6461,6 +6511,7 @@ if (Vdc<-2) {
                     type = bool
                     default_value = "False"
                     group = "Monitoring"
+                    no_evaluate
                 }
 
                 CODE open
@@ -7697,8 +7748,7 @@ if (Vdc<-2) {
 
         component Subsystem "Generator Control" {
             layout = dynamic
-            label = "GenCtrl"
-            component gen_bus_split "Bus Split1" {
+            component "core/Bus Split" "Bus Split1" {
                 outputs = "8"
             }
             [
@@ -7715,7 +7765,7 @@ if (Vdc<-2) {
                 size = 48, 80
             ]
 
-            component src_constant Constant3 {
+            component "core/Constant" Constant3 {
                 execution_rate = "execution_rate"
                 value = "0"
             }
@@ -7732,21 +7782,21 @@ if (Vdc<-2) {
                 size = 48, 80
             ]
 
-            component gen_product Product1 {
+            component "core/Product" Product1 {
             }
             [
                 position = 7016, 7448
                 hide_name = True
             ]
 
-            component gen_product Product2 {
+            component "core/Product" Product2 {
             }
             [
                 position = 7016, 7504
                 hide_name = True
             ]
 
-            component gen_sum Sum5 {
+            component "core/Sum" Sum5 {
                 signs = "++"
             }
             [
@@ -7754,7 +7804,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain9 {
+            component "core/Gain" Gain9 {
                 gain = "-1.5"
             }
             [
@@ -7762,31 +7812,30 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_probe P_gen {
+            component "core/Probe" P_gen {
                 signal_name = "P"
-                signal_type = "power"
-                streaming_en = "False"
+                signal_type = "active power"
             }
             [
                 position = 7296, 7432
                 rotation = left
             ]
 
-            component gen_product Product3 {
+            component "core/Product" Product3 {
             }
             [
                 position = 7016, 7672
                 hide_name = True
             ]
 
-            component gen_product Product4 {
+            component "core/Product" Product4 {
             }
             [
                 position = 7016, 7616
                 hide_name = True
             ]
 
-            component gen_sum Sum6 {
+            component "core/Sum" Sum6 {
                 signs = "+-"
             }
             [
@@ -7794,7 +7843,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain10 {
+            component "core/Gain" Gain10 {
                 gain = "-1.5"
             }
             [
@@ -7802,17 +7851,16 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_probe Q_gen {
+            component "core/Probe" Q_gen {
                 signal_name = "Q"
-                signal_type = "power"
-                streaming_en = "False"
+                signal_type = "active power"
             }
             [
                 position = 7296, 7600
                 rotation = left
             ]
 
-            component gen_sum Sum7 {
+            component "core/Sum" Sum7 {
                 signs = "+-"
             }
             [
@@ -7820,7 +7868,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_integrator Integrator3 {
+            component "core/Integrator" Integrator3 {
                 limit_lower = "-1.3"
                 limit_upper = "1.3"
             }
@@ -7829,7 +7877,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_sum Sum8 {
+            component "core/Sum" Sum8 {
                 signs = "++"
             }
             [
@@ -7837,7 +7885,8 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch3" {
+            component "core/Signal switch" "Signal switch3" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -7845,7 +7894,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component src_constant Constant4 {
+            component "core/Constant" Constant4 {
                 execution_rate = "execution_rate"
                 value = "0"
             }
@@ -7854,7 +7903,8 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch4" {
+            component "core/Signal switch" "Signal switch4" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -7862,7 +7912,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_sum Sum9 {
+            component "core/Sum" Sum9 {
                 signs = "+-"
             }
             [
@@ -7870,7 +7920,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_integrator Integrator4 {
+            component "core/Integrator" Integrator4 {
                 limit_lower = "-1.3"
                 limit_upper = "1.3"
             }
@@ -7879,7 +7929,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain13 {
+            component "core/Gain" Gain13 {
                 gain = "P_ki"
             }
             [
@@ -7887,7 +7937,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain14 {
+            component "core/Gain" Gain14 {
                 gain = "P_kp"
             }
             [
@@ -7895,7 +7945,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_sum Sum10 {
+            component "core/Sum" Sum10 {
                 signs = "++"
             }
             [
@@ -7903,7 +7953,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_limiter Limit4 {
+            component "core/Limit" Limit4 {
                 lower_limit = "1"
                 upper_limit = "10000"
             }
@@ -7912,7 +7962,8 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch5" {
+            component "core/Signal switch" "Signal switch5" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -7920,7 +7971,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component src_constant Constant5 {
+            component "core/Constant" Constant5 {
                 execution_rate = "execution_rate"
                 value = "0"
             }
@@ -7929,7 +7980,8 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch6" {
+            component "core/Signal switch" "Signal switch6" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -7937,7 +7989,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain15 {
+            component "core/Gain" Gain15 {
                 gain = "-1"
             }
             [
@@ -7945,7 +7997,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_bus_split "Bus Split2" {
+            component "core/Bus Split" "Bus Split2" {
                 outputs = "11"
             }
             [
@@ -7954,7 +8006,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_sum Sum11 {
+            component "core/Sum" Sum11 {
                 signs = "+-"
             }
             [
@@ -7962,14 +8014,14 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_product Product5 {
+            component "core/Product" Product5 {
             }
             [
                 position = 7016, 7312
                 hide_name = True
             ]
 
-            component gen_math_fnc "Mathematical function1" {
+            component "core/Mathematical function" "Mathematical function1" {
                 mathematical_fn = "sqrt"
             }
             [
@@ -7977,14 +8029,14 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_product Product6 {
+            component "core/Product" Product6 {
             }
             [
                 position = 7016, 7368
                 hide_name = True
             ]
 
-            component gen_sum Sum13 {
+            component "core/Sum" Sum13 {
                 signs = "++"
             }
             [
@@ -7992,17 +8044,16 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_probe V_gen {
+            component "core/Probe" V_gen {
                 signal_name = "V"
-                signal_type = "power"
-                streaming_en = "False"
+                signal_type = "active power"
             }
             [
                 position = 7320, 7296
                 rotation = left
             ]
 
-            component gen_gain Gain21 {
+            component "core/Gain" Gain21 {
                 gain = "0.001"
             }
             [
@@ -8010,7 +8061,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain22 {
+            component "core/Gain" Gain22 {
                 gain = "0.001"
             }
             [
@@ -8018,7 +8069,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain23 {
+            component "core/Gain" Gain23 {
                 gain = "1.224745"
             }
             [
@@ -8026,7 +8077,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component src_constant Constant9 {
+            component "core/Constant" Constant9 {
                 execution_rate = "execution_rate"
                 value = "ext_mode"
             }
@@ -8035,7 +8086,8 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch12" {
+            component "core/Signal switch" "Signal switch12" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8043,7 +8095,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain24 {
+            component "core/Gain" Gain24 {
                 gain = "Q_kp"
             }
             [
@@ -8051,7 +8103,8 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch13" {
+            component "core/Signal switch" "Signal switch13" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8059,7 +8112,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain25 {
+            component "core/Gain" Gain25 {
                 gain = "V_kp"
             }
             [
@@ -8067,7 +8120,8 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch14" {
+            component "core/Signal switch" "Signal switch14" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8075,7 +8129,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain26 {
+            component "core/Gain" Gain26 {
                 gain = "Q_ki"
             }
             [
@@ -8083,7 +8137,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_gain Gain27 {
+            component "core/Gain" Gain27 {
                 gain = "V_ki"
             }
             [
@@ -8091,7 +8145,7 @@ if (Vdc<-2) {
                 hide_name = True
             ]
 
-            component gen_c_function "C function1" {
+            component "core/C function" "C function1" {
                 input_terminals = "real mode_external;inherit Mode_select_ext;inherit Mode_select_int;"
                 input_terminals_dimensions = "inherit;inherit;inherit"
                 input_terminals_feedthrough = "True;True;True"
@@ -8144,7 +8198,7 @@ else {
                 size = 192, 96
             ]
 
-            component src_constant Constant13 {
+            component "core/Constant" Constant13 {
                 execution_rate = "execution_rate"
                 value = "ctrl_mode_int"
             }
@@ -8153,7 +8207,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_gain Gain28 {
+            component "core/Gain" Gain28 {
                 gain = "w_kp"
             }
             [
@@ -8161,7 +8215,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_gain Gain29 {
+            component "core/Gain" Gain29 {
                 gain = "w_ki"
             }
             [
@@ -8169,7 +8223,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_sum Sum14 {
+            component "core/Sum" Sum14 {
                 signs = "+-"
             }
             [
@@ -8177,7 +8231,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_gain Gain30 {
+            component "core/Gain" Gain30 {
                 gain = "2*np.pi"
             }
             [
@@ -8185,7 +8239,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_product Product7 {
+            component "core/Product" Product7 {
                 signs = "*/"
             }
             [
@@ -8193,7 +8247,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_gain Gain31 {
+            component "core/Gain" Gain31 {
                 gain = "0.5/np.pi"
             }
             [
@@ -8201,7 +8255,8 @@ else {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch15" {
+            component "core/Signal switch" "Signal switch15" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8209,7 +8264,8 @@ else {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch16" {
+            component "core/Signal switch" "Signal switch16" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8217,7 +8273,8 @@ else {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch17" {
+            component "core/Signal switch" "Signal switch17" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8225,7 +8282,7 @@ else {
                 hide_name = True
             ]
 
-            component src_constant Constant14 {
+            component "core/Constant" Constant14 {
                 execution_rate = "execution_rate"
             }
             [
@@ -8233,14 +8290,14 @@ else {
                 hide_name = True
             ]
 
-            component gen_gain Gain32 {
+            component "core/Gain" Gain32 {
             }
             [
                 position = 7080, 7848
                 hide_name = True
             ]
 
-            component gen_gain Gain33 {
+            component "core/Gain" Gain33 {
                 gain = "0.001"
             }
             [
@@ -8248,7 +8305,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_terminator Termination66 {
+            component "core/Termination" Termination66 {
             }
             [
                 position = 6688, 7536
@@ -8256,7 +8313,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_terminator Termination67 {
+            component "core/Termination" Termination67 {
             }
             [
                 position = 6688, 7480
@@ -8264,14 +8321,15 @@ else {
                 hide_name = True
             ]
 
-            component gen_terminator Termination68 {
+            component "core/Termination" Termination68 {
             }
             [
                 position = 6208, 7552
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch18" {
+            component "core/Signal switch" "Signal switch18" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8279,7 +8337,8 @@ else {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch19" {
+            component "core/Signal switch" "Signal switch19" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8287,7 +8346,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_sum Sum15 {
+            component "core/Sum" Sum15 {
                 signs = "+-"
             }
             [
@@ -8295,7 +8354,7 @@ else {
                 hide_name = True
             ]
 
-            component gen_sum Sum16 {
+            component "core/Sum" Sum16 {
                 signs = "+-"
             }
             [
@@ -8303,7 +8362,8 @@ else {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch20" {
+            component "core/Signal switch" "Signal switch20" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8311,7 +8371,8 @@ else {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch21" {
+            component "core/Signal switch" "Signal switch21" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8319,7 +8380,8 @@ else {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch22" {
+            component "core/Signal switch" "Signal switch22" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8327,7 +8389,8 @@ else {
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch23" {
+            component "core/Signal switch" "Signal switch23" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -8335,10 +8398,9 @@ else {
                 hide_name = True
             ]
 
-            component gen_probe gents {
+            component "core/Probe" gents {
                 signal_name = "Q"
-                signal_type = "power"
-                streaming_en = "False"
+                signal_type = "active power"
             }
             [
                 position = 8032, 7184
@@ -9531,6 +9593,7 @@ else {
             connect Junction40 "Signal switch13.in" as Connection503
             connect "Signal switch20.in" Junction40 as Connection504
             [
+                position = 0, 0
                 breakpoints = 8544, 7296; 8464, 7296
             ]
             connect From93 "Signal switch21.in2" as Connection506
@@ -9552,31 +9615,37 @@ else {
             connect gents.in Junction44 as Connection528
             connect "Signal switch17.out" "Signal switch19.in1" as Connection547
             [
+                position = 0, 0
                 breakpoints = 8168, 7704; 8168, 7704; 8168, 7960; 8152, 7960; 8088, 7960
             ]
             connect "Signal switch5.in" "Signal switch19.out" as Connection548
             connect "Signal switch18.in1" "Signal switch12.out" as Connection549
             [
+                position = 0, 0
                 breakpoints = 8056, 7440
             ]
             connect "Signal switch3.in" "Signal switch18.out" as Connection550
             connect "Signal switch13.out" "Signal switch20.in1" as Connection551
             [
+                position = 0, 0
                 breakpoints = 8568, 7352
             ]
             connect "Signal switch20.out" Sum8.in as Connection552
             connect "Signal switch21.in1" "Signal switch14.out" as Connection553
             [
+                position = 0, 0
                 breakpoints = 8576, 7488
             ]
             connect "Signal switch21.out" Integrator3.in as Connection554
             connect "Signal switch15.out" "Signal switch22.in1" as Connection555
             [
+                position = 0, 0
                 breakpoints = 8536, 7688
             ]
             connect Sum10.in "Signal switch22.out" as Connection556
             connect "Signal switch16.out" "Signal switch23.in1" as Connection557
             [
+                position = 0, 0
                 breakpoints = 8576, 7800
             ]
             connect "Signal switch23.out" Integrator4.in as Connection558
@@ -10108,7 +10177,7 @@ else {
         component Subsystem Generator {
             layout = static
             label = "Gen"
-            component gen_c_function "C function2" {
+            component "core/C function" "C function2" {
                 global_variables = "real thet_r_mem;real wr_k1;real wr_k2;real wm_mem;real psifd_mem;real psikq_mem;real wr_est;real Te_mem;real psikq2_mem;real psikd_mem;real ppsikq;real ppsikq2;real ppsikd;real ppsifd;"
                 init_fnc = "/*Begin code section*/
 psifd_mem = 0.0;
@@ -10202,7 +10271,7 @@ Te_mem = Te;
                 size = 240, 472
             ]
 
-            component pas_resistor R1 {
+            component "core/Resistor" R1 {
                 resistance = "rs"
             }
             [
@@ -10210,7 +10279,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component pas_inductor L2 {
+            component "core/Inductor" L2 {
                 inductance = "Lls+Lmzd"
             }
             [
@@ -10218,7 +10287,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component pas_inductor L1 {
+            component "core/Inductor" L1 {
                 inductance = "Lls+Lmzd"
             }
             [
@@ -10246,7 +10315,7 @@ Te_mem = Te;
                 size = 64, 32
             ]
 
-            component pas_resistor R2 {
+            component "core/Resistor" R2 {
                 resistance = "rs"
             }
             [
@@ -10271,7 +10340,7 @@ Te_mem = Te;
                 size = 64, 32
             ]
 
-            component pas_resistor R3 {
+            component "core/Resistor" R3 {
                 resistance = "rs"
             }
             [
@@ -10279,7 +10348,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component pas_inductor L3 {
+            component "core/Inductor" L3 {
                 inductance = "Lls+Lmzd"
             }
             [
@@ -10346,7 +10415,7 @@ Te_mem = Te;
                 size = 64, 32
             ]
 
-            component src_constant Constant3 {
+            component "core/Constant" Constant3 {
                 execution_rate = "Ts"
                 value = "0.0"
             }
@@ -10372,7 +10441,7 @@ Te_mem = Te;
                 size = 48, 80
             ]
 
-            component src_constant Constant4 {
+            component "core/Constant" Constant4 {
                 execution_rate = "Ts"
                 value = "Ts"
             }
@@ -10381,14 +10450,14 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component tm_delay "Unit Delay2" {
+            component "core/Unit Delay" "Unit Delay2" {
             }
             [
                 position = 4840, 7576
                 hide_name = True
             ]
 
-            component src_constant Constant5 {
+            component "core/Constant" Constant5 {
                 execution_rate = "Ts"
                 value = "0"
             }
@@ -10397,7 +10466,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_gain Gain1 {
+            component "core/Gain" Gain1 {
                 gain = "3"
             }
             [
@@ -10405,7 +10474,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant6 {
+            component "core/Constant" Constant6 {
                 execution_rate = "Ts"
                 value = "0.5/Ts"
             }
@@ -10414,14 +10483,14 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component tm_delay "Unit Delay3" {
+            component "core/Unit Delay" "Unit Delay3" {
             }
             [
                 position = 5560, 7960
                 hide_name = True
             ]
 
-            component gen_gain Gain2 {
+            component "core/Gain" Gain2 {
                 gain = "4"
             }
             [
@@ -10429,7 +10498,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_sum Sum1 {
+            component "core/Sum" Sum1 {
                 signs = "+-+"
             }
             [
@@ -10438,60 +10507,57 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_product Product1 {
+            component "core/Product" Product1 {
             }
             [
                 position = 5792, 8088
                 hide_name = True
             ]
 
-            component tm_delay "Unit Delay4" {
+            component "core/Unit Delay" "Unit Delay4" {
             }
             [
                 position = 5648, 8000
                 hide_name = True
             ]
 
-            component tm_delay "Unit Delay8" {
+            component "core/Unit Delay" "Unit Delay8" {
             }
             [
                 position = 6336, 7520
                 hide_name = True
             ]
 
-            component tm_delay "Unit Delay9" {
+            component "core/Unit Delay" "Unit Delay9" {
             }
             [
                 position = 6392, 7544
                 hide_name = True
             ]
 
-            component gen_probe Tm {
+            component "core/Probe" Tm {
                 signal_type = "torque"
-                streaming_en = "False"
             }
             [
                 position = 4744, 7584
                 rotation = right
             ]
 
-            component gen_probe Te {
+            component "core/Probe" Te {
                 signal_type = "torque"
-                streaming_en = "False"
             }
             [
                 position = 5760, 7880
             ]
 
-            component gen_probe vfd_p {
+            component "core/Probe" vfd_p {
                 signal_type = "voltage"
-                streaming_en = "False"
             }
             [
                 position = 6008, 7592
             ]
 
-            component src_constant Constant13 {
+            component "core/Constant" Constant13 {
                 execution_rate = "Ts"
                 value = "ws/PP"
             }
@@ -10500,23 +10566,21 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_probe psifd {
+            component "core/Probe" psifd {
                 signal_type = "flux"
-                streaming_en = "False"
             }
             [
                 position = 5256, 7448
             ]
 
-            component gen_probe Tm_p {
+            component "core/Probe" Tm_p {
                 signal_type = "torque"
-                streaming_en = "False"
             }
             [
                 position = 5928, 7880
             ]
 
-            component gen_gain Gain3 {
+            component "core/Gain" Gain3 {
                 gain = "ws_inv"
             }
             [
@@ -10524,7 +10588,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_gain Gain4 {
+            component "core/Gain" Gain4 {
                 gain = "Lmd"
             }
             [
@@ -10532,7 +10596,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_sum Sum2 {
+            component "core/Sum" Sum2 {
                 signs = "+-"
             }
             [
@@ -10540,7 +10604,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_gain Gain5 {
+            component "core/Gain" Gain5 {
                 gain = "1/Lmd"
             }
             [
@@ -10548,24 +10612,22 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_probe w_mech {
+            component "core/Probe" w_mech {
                 signal_type = "angular speed"
-                streaming_en = "False"
             }
             [
                 position = 6704, 7928
                 rotation = down
             ]
 
-            component gen_probe psimd {
+            component "core/Probe" psimd {
                 signal_type = "flux"
-                streaming_en = "False"
             }
             [
                 position = 5344, 7512
             ]
 
-            component gen_gain Gain6 {
+            component "core/Gain" Gain6 {
                 gain = "rfd"
             }
             [
@@ -10573,7 +10635,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant14 {
+            component "core/Constant" Constant14 {
                 execution_rate = "Ts"
                 value = "0.0"
             }
@@ -10582,7 +10644,8 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch1" {
+            component "core/Signal switch" "Signal switch1" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -10590,7 +10653,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_sum Sum3 {
+            component "core/Sum" Sum3 {
                 signs = "++"
             }
             [
@@ -10599,7 +10662,7 @@ Te_mem = Te;
                 scale = 1, -1
             ]
 
-            component gen_limiter Limit1 {
+            component "core/Limit" Limit1 {
                 lower_limit = "0"
             }
             [
@@ -10607,7 +10670,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component tm_delay "Unit Delay10" {
+            component "core/Unit Delay" "Unit Delay10" {
             }
             [
                 position = 5752, 7568
@@ -10615,7 +10678,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_z_domain_transfer "Discrete Transfer Function1" {
+            component "core/Discrete Transfer Function" "Discrete Transfer Function1" {
                 a_coeff = "[0.1,1]"
                 domain = "S-domain"
                 method = "Euler"
@@ -10625,7 +10688,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_sum Sum4 {
+            component "core/Sum" Sum4 {
                 signs = "++"
             }
             [
@@ -10634,7 +10697,8 @@ Te_mem = Te;
                 scale = 1, -1
             ]
 
-            component sys_signal_switch "Signal switch2" {
+            component "core/Signal switch" "Signal switch2" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -10642,7 +10706,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component tm_delay "Unit Delay11" {
+            component "core/Unit Delay" "Unit Delay11" {
             }
             [
                 position = 5648, 7752
@@ -10650,22 +10714,22 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component tm_delay "Unit Delay13" {
+            component "core/Unit Delay" "Unit Delay13" {
             }
             [
                 position = 5840, 7824
                 hide_name = True
             ]
 
-            component gen_probe psimq {
+            component "core/Probe" psimq {
                 signal_type = "flux"
-                streaming_en = "False"
             }
             [
                 position = 5288, 7544
             ]
 
-            component sys_signal_switch "Signal switch3" {
+            component "core/Signal switch" "Signal switch3" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -10673,7 +10737,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant18 {
+            component "core/Constant" Constant18 {
                 execution_rate = "Ts"
                 value = "Init_switch"
             }
@@ -10682,7 +10746,8 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch4" {
+            component "core/Signal switch" "Signal switch4" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -10690,21 +10755,21 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_comparator Comparator1 {
+            component "core/Comparator" Comparator1 {
             }
             [
                 position = 5616, 7456
                 hide_name = True
             ]
 
-            component gen_comparator Comparator2 {
+            component "core/Comparator" Comparator2 {
             }
             [
                 position = 5616, 7520
                 hide_name = True
             ]
 
-            component src_constant Constant19 {
+            component "core/Constant" Constant19 {
                 execution_rate = "Ts"
                 value = "thet_ph_init"
             }
@@ -10713,7 +10778,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant20 {
+            component "core/Constant" Constant20 {
                 execution_rate = "Ts"
                 value = "V_ph_init"
             }
@@ -10722,7 +10787,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_gain Gain7 {
+            component "core/Gain" Gain7 {
                 gain = "1414.2135"
             }
             [
@@ -10730,7 +10795,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_clock Clock1 {
+            component "core/Clock" Clock1 {
                 execution_rate = "Ts"
             }
             [
@@ -10739,7 +10804,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant21 {
+            component "core/Constant" Constant21 {
                 execution_rate = "Ts"
                 value = "V2M_t"
             }
@@ -10748,7 +10813,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant23 {
+            component "core/Constant" Constant23 {
                 execution_rate = "Ts"
                 value = "Mech_En"
             }
@@ -10775,7 +10840,7 @@ Te_mem = Te;
                 size = 32, 32
             ]
 
-            component src_constant Constant24 {
+            component "core/Constant" Constant24 {
                 execution_rate = "Ts"
                 value = "Init_switch"
             }
@@ -10784,7 +10849,8 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch5" {
+            component "core/Signal switch" "Signal switch5" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -10793,7 +10859,8 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component sys_signal_switch "Signal switch6" {
+            component "core/Signal switch" "Signal switch6" {
+                criterion = "ctrl >= threshold"
                 threshold = "0.5"
             }
             [
@@ -10802,7 +10869,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant25 {
+            component "core/Constant" Constant25 {
                 execution_rate = "Ts"
             }
             [
@@ -10819,7 +10886,7 @@ Te_mem = Te;
                 size = 64, 32
             ]
 
-            component gen_bus_join "Bus Join3" {
+            component "core/Bus Join" "Bus Join3" {
                 inputs = "8"
             }
             [
@@ -10827,7 +10894,7 @@ Te_mem = Te;
                 rotation = right
             ]
 
-            component src_constant Constant26 {
+            component "core/Constant" Constant26 {
                 execution_rate = "Ts"
                 value = "Init_switch"
             }
@@ -10836,7 +10903,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_bus_join "Bus Join4" {
+            component "core/Bus Join" "Bus Join4" {
                 inputs = "11"
             }
             [
@@ -10845,7 +10912,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant27 {
+            component "core/Constant" Constant27 {
                 execution_rate = "Ts"
                 value = "kw"
             }
@@ -10854,7 +10921,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant28 {
+            component "core/Constant" Constant28 {
                 execution_rate = "Ts"
                 value = "kvar"
             }
@@ -10863,7 +10930,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant29 {
+            component "core/Constant" Constant29 {
                 execution_rate = "Ts"
                 value = "kv"
             }
@@ -10872,7 +10939,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant30 {
+            component "core/Constant" Constant30 {
                 execution_rate = "Ts"
                 value = "PP"
             }
@@ -10881,7 +10948,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant31 {
+            component "core/Constant" Constant31 {
                 execution_rate = "Ts"
                 value = "ws"
             }
@@ -10890,28 +10957,28 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_terminator Termination60 {
+            component "core/Termination" Termination60 {
             }
             [
                 position = 5280, 7768
                 hide_name = True
             ]
 
-            component gen_terminator Termination61 {
+            component "core/Termination" Termination61 {
             }
             [
                 position = 5216, 7800
                 hide_name = True
             ]
 
-            component gen_terminator Termination62 {
+            component "core/Termination" Termination62 {
             }
             [
                 position = 5280, 7672
                 hide_name = True
             ]
 
-            component gen_terminator Termination63 {
+            component "core/Termination" Termination63 {
             }
             [
                 position = 6344, 7592
@@ -10919,7 +10986,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component gen_terminator Termination64 {
+            component "core/Termination" Termination64 {
             }
             [
                 position = 5216, 7480
@@ -10928,27 +10995,27 @@ Te_mem = Te;
 
             component Subsystem TS_module {
                 layout = dynamic
-                component src_clock Clock1 {
+                component "core/Clock" Clock1 {
                     execution_rate = "Texec"
                 }
                 [
                     position = 6824, 8000
                 ]
 
-                component gen_probe d_rel {
+                component "core/Probe" d_rel {
                     signal_name = "Delay release"
                 }
                 [
                     position = 6928, 7936
                 ]
 
-                component gen_comparator Comparator1 {
+                component "core/Comparator" Comparator1 {
                 }
                 [
                     position = 6928, 8000
                 ]
 
-                component src_constant Constant1 {
+                component "core/Constant" Constant1 {
                     execution_rate = "Texec"
                     value = "Tdel"
                 }
@@ -10956,21 +11023,22 @@ Te_mem = Te;
                     position = 6824, 8064
                 ]
 
-                component sys_signal_switch "Signal switch1" {
-                    threshold = "0.5"
+                component "core/Signal switch" "Signal switch1" {
+                    criterion = "ctrl >= threshold"
+                threshold = "0.5"
                 }
                 [
                     position = 7008, 8144
                 ]
 
-                component src_constant Constant3 {
+                component "core/Constant" Constant3 {
                     execution_rate = "Texec"
                 }
                 [
                     position = 6840, 8128
                 ]
 
-                component gen_integrator Integrator1 {
+                component "core/Integrator" Integrator1 {
                     show_reset = "rising"
                     show_state = "True"
                 }
@@ -10978,7 +11046,7 @@ Te_mem = Te;
                     position = 7352, 8152
                 ]
 
-                component src_constant Constant4 {
+                component "core/Constant" Constant4 {
                     execution_rate = "Texec"
                     value = "Tmax"
                 }
@@ -10986,13 +11054,13 @@ Te_mem = Te;
                     position = 7152, 8304
                 ]
 
-                component gen_comparator Comparator2 {
+                component "core/Comparator" Comparator2 {
                 }
                 [
                     position = 7240, 8296
                 ]
 
-                component lut_1d "1D look-up table1" {
+                component "core/1D look-up table" "1D look-up table1" {
                     in_vec_x = "T_vecP"
                     out_vec_f_x = "P_vec1"
                 }
@@ -11000,7 +11068,7 @@ Te_mem = Te;
                     position = 7608, 8008
                 ]
 
-                component lut_1d "1D look-up table2" {
+                component "core/1D look-up table" "1D look-up table2" {
                     in_vec_x = "T_vecQ"
                     out_vec_f_x = "Q_vec1"
                 }
@@ -11008,7 +11076,7 @@ Te_mem = Te;
                     position = 7608, 8192
                 ]
 
-                component src_constant Constant5 {
+                component "core/Constant" Constant5 {
                     execution_rate = "Texec"
                     value = "0"
                 }
@@ -11016,14 +11084,15 @@ Te_mem = Te;
                     position = 6840, 8176
                 ]
 
-                component sys_signal_switch "Signal switch2" {
+                component "core/Signal switch" "Signal switch2" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
                     position = 7176, 8144
                 ]
 
-                component src_constant Constant6 {
+                component "core/Constant" Constant6 {
                     execution_rate = "Texec"
                     value = "loop_en"
                 }
@@ -11031,14 +11100,15 @@ Te_mem = Te;
                     position = 7112, 8048
                 ]
 
-                component sys_signal_switch "Signal switch3" {
+                component "core/Signal switch" "Signal switch3" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
                     position = 7456, 8160
                 ]
 
-                component src_constant Constant7 {
+                component "core/Constant" Constant7 {
                     execution_rate = "Texec"
                     value = "loop_en"
                 }
@@ -11046,7 +11116,7 @@ Te_mem = Te;
                     position = 7400, 8064
                 ]
 
-                component gen_gain Gain1 {
+                component "core/Gain" Gain1 {
                 }
                 [
                     position = 7384, 8352
@@ -11423,7 +11493,7 @@ Te_mem = Te;
                 size = 112, 72
             ]
 
-            component src_constant Constant32 {
+            component "core/Constant" Constant32 {
                 execution_rate = "Ts"
                 value = "gen_ts_en_bit"
             }
@@ -11432,7 +11502,7 @@ Te_mem = Te;
                 hide_name = True
             ]
 
-            component src_constant Constant33 {
+            component "core/Constant" Constant33 {
                 execution_rate = "Ts"
                 value = "0"
             }
@@ -11443,20 +11513,21 @@ Te_mem = Te;
 
             component Subsystem T_switch {
                 layout = dynamic
-                component sys_signal_switch "Signal switch1" {
+                component "core/Signal switch" "Signal switch1" {
+                    criterion = "ctrl >= threshold"
                     threshold = "0.5"
                 }
                 [
                     position = 7632, 8056
                 ]
 
-                component gen_round Round1 {
+                component "core/Round" Round1 {
                 }
                 [
                     position = 7392, 8072
                 ]
 
-                component gen_limiter Limit1 {
+                component "core/Limit" Limit1 {
                     lower_limit = "T_lim_low"
                     upper_limit = "T_lim_high"
                 }
@@ -11533,7 +11604,7 @@ Te_mem = Te;
                 size = 72, 64
             ]
 
-            component src_constant Constant102 {
+            component "core/Constant" Constant102 {
                 execution_rate = "Ts"
                 value = "Ts_switch"
             }
@@ -12834,6 +12905,7 @@ Te_mem = Te;
                     default_value = "60"
                     unit = "Hz"
                     group = "General"
+                    nonvisible
                 }
 
                 nom_rpm {
@@ -13501,6 +13573,7 @@ Te_mem = Te;
                     default_value = "Daily"
                     group = "OpenDSS model setting"
                     nonvisible
+                    no_evaluate
                 }
 
                 T_Ts_internal {
@@ -13589,6 +13662,7 @@ Te_mem = Te;
                     type = bool
                     default_value = "False"
                     group = "Monitoring"
+                    no_evaluate
                 }
 
                 CODE open
@@ -13971,10 +14045,10 @@ Te_mem = Te;
         component Subsystem Vsource {
             layout = static
             label = "V"
-            component src_voltage Va {
-                init_frequency = "60"
-                init_phase = "0"
-                init_rms_value = "66395.28095681"
+            component "core/Voltage Source" Va {
+                init_frequency = "Frequency"
+                init_phase = "Angle - 0"
+                init_rms_value = "round(basekv * 1000 * pu/ np.sqrt(3), 8)"
                 init_source_nature = "Sine"
             }
             [
@@ -13982,10 +14056,10 @@ Te_mem = Te;
                 rotation = down
             ]
 
-            component src_voltage Vb {
-                init_frequency = "60"
-                init_phase = "-120"
-                init_rms_value = "66395.28095681"
+            component "core/Voltage Source" Vb {
+                init_frequency = "Frequency"
+                init_phase = "Angle - 120"
+                init_rms_value = "round(basekv * 1000 * pu/ np.sqrt(3), 8)"
                 init_source_nature = "Sine"
             }
             [
@@ -13993,10 +14067,10 @@ Te_mem = Te;
                 rotation = down
             ]
 
-            component src_voltage Vc {
-                init_frequency = "60"
-                init_phase = "-240"
-                init_rms_value = "66395.28095681"
+            component "core/Voltage Source" Vc {
+                init_frequency = "Frequency"
+                init_phase = "Angle - 240"
+                init_rms_value = "round(basekv * 1000 * pu/ np.sqrt(3), 8)"
                 init_source_nature = "Sine"
             }
             [
@@ -14004,7 +14078,7 @@ Te_mem = Te;
                 rotation = down
             ]
 
-            component src_ground gnd1 {
+            component "core/Ground" gnd1 {
             }
             [
                 position = 8000, 8400
@@ -14012,9 +14086,9 @@ Te_mem = Te;
 
             component "core/Transmission Line" TL1 {
                 Frequency = "60"
-                L_sequence_metric = "[[0.015119719593730058, 0, 0], [0, 0.017507043740108485, 0], [0, 0, 0.017507043740108485]]"
+                L_sequence_metric = "[[x0 / 2 / np.pi / Frequency, 0, 0], [0, x1 / 2 / np.pi / Frequency, 0], [0, 0, x1 / 2 / np.pi / Frequency]]"
                 Length_metric = "1"
-                R_sequence_metric = "[[1.9, 0, 0], [0, 1.65, 0], [0, 0, 1.65]]"
+                R_sequence_metric = "[[r0, 0, 0], [0, r1, 0], [0, 0, r1]]"
                 model_def = "Sequence"
                 unit_sys = "metric"
             }
@@ -14220,6 +14294,7 @@ Te_mem = Te;
                     type = bool
                     default_value = "False"
                     group = "Monitoring"
+                    no_evaluate
                 }
 
                 CODE open
@@ -14273,21 +14348,21 @@ Te_mem = Te;
 
         component Subsystem "Manual Switch" {
             layout = static
-            component el_short SC_A {
+            component "core/Short Circuit" SC_A {
                 circuit_connector = "true"
             }
             [
                 position = 7744, 7856
             ]
 
-            component el_short SC_B {
+            component "core/Short Circuit" SC_B {
                 circuit_connector = "true"
             }
             [
                 position = 7744, 7952
             ]
 
-            component el_short SC_C {
+            component "core/Short Circuit" SC_C {
                 circuit_connector = "true"
             }
             [
@@ -14448,6 +14523,7 @@ Te_mem = Te;
                     widget = button
                     type = string
                     default_value = "Apply"
+                    no_evaluate
 
                     CODE button_clicked
                         import comp_container
@@ -14460,8 +14536,8 @@ Te_mem = Te;
                     widget = edit
                     type = string
                     default_value = "None"
-                    no_evaluate
                     nonvisible
+                    no_evaluate
                 }
 
                 CODE open
@@ -14528,7 +14604,7 @@ Te_mem = Te;
             }
             [
                 position = 7736, 7952
-                size = 0, 0
+                size = 64, 256
             ]
 
             port ctrl {
@@ -14772,6 +14848,14 @@ Te_mem = Te;
 
         component Subsystem Fault {
             layout = static
+            component "core/Grid Fault" F1 {
+                fault_type = "A-B-C-GND"
+                resistance = "0.00030000000000000003"
+            }
+            [
+                position = 7736, 7952
+                size = 64, 64
+            ]
 
             port A1 {
                 label = "A1"
@@ -14827,7 +14911,7 @@ Te_mem = Te;
 
             port C2 {
                 label = "C2"
-                position = 32, 32
+                position = 32.0, 32.0
                 kind = pe
                 direction =  in
             }
@@ -14836,9 +14920,23 @@ Te_mem = Te;
                 scale = -1, 1
             ]
 
-            connect A1 A2 as Connection1
-            connect B1 B2 as Connection2
-            connect C1 C2 as Connection3
+            port gnd {
+                position = bottom center
+                kind = pe
+                direction =  in
+            }
+            [
+                position = 7736, 8144
+                rotation = left
+            ]
+
+            connect A1 F1.A1 as Connection1
+            connect B1 F1.B1 as Connection2
+            connect C1 F1.C1 as Connection3
+            connect A2 F1.A2 as Connection4
+            connect B2 F1.B2 as Connection5
+            connect C2 F1.C2 as Connection6
+            connect gnd F1.GND as Connection7
 
             mask {
                 description = "<html><head><meta name=\"qrichtext\" content=\"1\"></meta><style type=\"text/css\">p, li { white-space: pre-wrap; }</style></head><body style=\"\"><p style=\"margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">The OpenDSS Fault object is a resistor network, a two-terminal device in which the second terminal defaults to ground.<br><br>Only one Bus must be connected to either side this component.</p></body></html>"
@@ -14938,26 +15036,6 @@ Te_mem = Te;
                 size = 124, 256
             ]
 
-            port A2 {
-                position = 32.0, -16.0
-                kind = pe
-                direction =  in
-            }
-            [
-                position = 9320, 8104
-                scale = -1, 1
-            ]
-
-            port B2 {
-                position = 32.0, 16.0
-                kind = pe
-                direction =  in
-            }
-            [
-                position = 9320, 8296
-                scale = -1, 1
-            ]
-
             port A1 {
                 position = -32.0, -16.0
                 kind = pe
@@ -14974,98 +15052,24 @@ Te_mem = Te;
                 position = 7992, 8296
             ]
 
-            tag TagA2 {
-                value = "TA_2"
-                scope = local
+            port A2 {
+                position = 32, -16
                 kind = pe
+                direction =  in
             }
             [
-                position = 9200, 8104
-                size = 60, 20
-            ]
-
-            tag TagB2 {
-                value = "TB_2"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 9200, 8296
-                size = 59, 20
-            ]
-
-            tag TagRegA1 {
-                value = "not_used"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 8696, 8104
-                size = 60, 20
-            ]
-
-            tag TagRegB1 {
-                value = "not_used"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 8696, 8296
-                size = 59, 20
-            ]
-
-            tag TagRegA2 {
-                value = "not_used"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 9064, 8104
+                position = 9376, 8192
                 scale = -1, 1
-                size = 60, 20
             ]
 
-            tag TagRegB2 {
-                value = "not_used"
-                scope = local
+            port B2 {
+                position = 32, 16
                 kind = pe
+                direction =  in
             }
             [
-                position = 9064, 8296
+                position = 9376, 8288
                 scale = -1, 1
-                size = 59, 20
-            ]
-
-            tag TagTB2 {
-                value = "TB_2"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 8576, 8296
-                scale = -1, 1
-                size = 60, 20
-            ]
-
-            tag TagTA2 {
-                value = "TA_2"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 8576, 8104
-                scale = -1, 1
-                size = 60, 20
-            ]
-
-            tag TagTB1 {
-                value = "TB_1"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 8240, 8296
-                size = 60, 20
             ]
 
             tag TagA1 {
@@ -15100,14 +15104,67 @@ Te_mem = Te;
                 size = 60, 20
             ]
 
+            tag TagTB1 {
+                value = "TB_1"
+                scope = local
+                kind = pe
+            }
+            [
+                position = 8240, 8296
+                size = 60, 20
+            ]
+
+            tag TagTA2 {
+                value = "TA_2"
+                scope = local
+                kind = pe
+            }
+            [
+                position = 8560, 8160
+                scale = -1, 1
+                size = 60, 20
+            ]
+
+            tag TagTB2 {
+                value = "TB_2"
+                scope = local
+                kind = pe
+            }
+            [
+                position = 8560, 8240
+                scale = -1, 1
+                size = 60, 20
+            ]
+
+             tag TagA2 {
+                value = "TA_2"
+                scope = local
+                kind = pe
+            }
+            [
+                position = 9272, 8192
+                size = 60, 20
+            ]
+
+            tag TagB2 {
+                value = "TB_2"
+                scope = local
+                kind = pe
+            }
+            [
+                position = 9272, 8288
+                size = 60, 20
+            ]
+
             connect A1 TagA1 as Connection91
             connect TagB1 B1 as Connection92
-            connect TagTB1 T1.prm_2 as Connection93
-            connect TagTA2 T1.sec_1 as Connection95
+            connect T1.prm_1 TagTA1 as Connection93
+            connect T1.prm_2 TagTB1 as Connection94
+            connect T1.sec_1 TagTA2 as Connection95
             connect T1.sec_2 TagTB2 as Connection96
             connect TagA2 A2 as Connection97
             connect TagB2 B2 as Connection98
-            connect T1.prm_1 TagTA1 as Connection99
+
 
             KVAs = "[1000, 1000]"
             KVs = "[12.47, 12.47]"
@@ -15165,6 +15222,7 @@ Te_mem = Te;
                     type = string
                     default_value = "None"
                     group = "Core coupling:3"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -15182,6 +15240,7 @@ Te_mem = Te;
                     type = string
                     default_value = "None"
                     group = "Core coupling:3"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -15199,6 +15258,7 @@ Te_mem = Te;
                     type = string
                     default_value = "None"
                     group = "Core coupling:3"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -15216,6 +15276,7 @@ Te_mem = Te;
                     type = string
                     default_value = "None"
                     group = "Core coupling:3"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -15233,6 +15294,7 @@ Te_mem = Te;
                     type = string
                     default_value = "None"
                     group = "Core coupling:3"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -15250,6 +15312,7 @@ Te_mem = Te;
                     type = string
                     default_value = "None"
                     group = "Core coupling:3"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -15267,6 +15330,7 @@ Te_mem = Te;
                     type = string
                     default_value = "None"
                     group = "Core coupling:3"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -15284,6 +15348,7 @@ Te_mem = Te;
                     type = string
                     default_value = "None"
                     group = "Core coupling:3"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -15534,6 +15599,7 @@ Te_mem = Te;
                     type = bool
                     default_value = "False"
                     group = "Monitoring:5"
+                    no_evaluate
                 }
 
                 CODE open
@@ -15636,33 +15702,6 @@ Te_mem = Te;
                 position = 8056, 8232
             ]
 
-            port A2 {
-                position = 32.0, -32.0
-                kind = pe
-            }
-            [
-                position = 9408, 8088
-                scale = -1, 1
-            ]
-
-            port B2 {
-                position = 32.0, 0.0
-                kind = pe
-            }
-            [
-                position = 9408, 8160
-                scale = -1, 1
-            ]
-
-            port C2 {
-                position = 32.0, 32.0
-                kind = pe
-            }
-            [
-                position = 9408, 8240
-                scale = -1, 1
-            ]
-
             port N1 {
                 position = -24, 48
                 kind = pe
@@ -15679,6 +15718,36 @@ Te_mem = Te;
             }
             [
                 position = 8496, 8496
+                scale = -1, 1
+            ]
+
+            port A2 {
+                position = 32, -32
+                kind = pe
+                direction =  in
+            }
+            [
+                position = 9376, 8144
+                scale = -1, 1
+            ]
+
+            port B2 {
+                position = 32, 0
+                kind = pe
+                direction =  in
+            }
+            [
+                position = 9376, 8240
+                scale = -1, 1
+            ]
+
+            port C2 {
+                position = 32, 32
+                kind = pe
+                direction =  in
+            }
+            [
+                position = 9376, 8336
                 scale = -1, 1
             ]
 
@@ -15715,105 +15784,53 @@ Te_mem = Te;
                 size = 60, 20
             ]
 
-            tag TagA2 {
+             tag TagTA1 {
+                value = "TA_1"
+                scope = local
+                kind = pe
+            }
+            [
+                position = 8256, 8096
+                size = 60, 20
+            ]
+
+            tag TagTB1 {
+                value = "TB_1"
+                scope = local
+                kind = pe
+            }
+            [
+                position = 8256, 8192
+                size = 60, 20
+            ]
+
+            tag TagTC1 {
+                value = "TC_1"
+                scope = local
+                kind = pe
+            }
+            [
+                position = 8256, 8288
+                size = 60, 20
+            ]
+
+            tag TagTN1 {
+                value = "T_N1"
+                scope = local
+                kind = pe
+            }
+            [
+                position = 8256, 8416
+                size = 60, 20
+            ]
+
+            tag TagTA2 {
                 value = "TA_2"
                 scope = local
                 kind = pe
             }
             [
-                position = 9272, 8088
-                size = 60, 20
-            ]
-
-            tag TagB2 {
-                value = "TB_2"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 9272, 8160
-                size = 59, 20
-            ]
-
-            tag TagC2 {
-                value = "TC_2"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 9272, 8240
-                size = 60, 20
-            ]
-
-            tag TagRegA1 {
-                value = "not_used"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 8800, 8088
-                size = 60, 20
-            ]
-
-            tag TagRegB1 {
-                value = "not_used"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 8800, 8184
-                size = 59, 20
-            ]
-
-            tag TagRegC1 {
-                value = "not_used"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 8800, 8280
-                size = 60, 20
-            ]
-
-            tag Reg_N1 {
-                value = "T_N2"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 8800, 8376
-                size = 60, 20
-            ]
-
-            tag TagRegA2 {
-                value = "not_used"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 9120, 8088
-                scale = -1, 1
-                size = 60, 20
-            ]
-
-            tag TagRegB2 {
-                value = "not_used"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 9120, 8232
-                scale = -1, 1
-                size = 59, 20
-            ]
-
-            tag TagRegC2 {
-                value = "not_used"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 9120, 8376
+                position = 8600, 8096
                 scale = -1, 1
                 size = 60, 20
             ]
@@ -15851,44 +15868,33 @@ Te_mem = Te;
                 size = 60, 20
             ]
 
-            tag TagTA2 {
+            tag TagA2 {
                 value = "TA_2"
                 scope = local
                 kind = pe
             }
             [
-                position = 8600, 8096
-                scale = -1, 1
+                position = 9272, 8144
                 size = 60, 20
             ]
 
-            tag TagTB1 {
-                value = "TB_1"
+            tag TagB2 {
+                value = "TB_2"
                 scope = local
                 kind = pe
             }
             [
-                position = 8296, 8192
+                position = 9272, 8240
                 size = 60, 20
             ]
 
-            tag TagTC1 {
-                value = "TC_1"
+            tag TagC2 {
+                value = "TC_2"
                 scope = local
                 kind = pe
             }
             [
-                position = 8296, 8288
-                size = 60, 20
-            ]
-
-            tag TagTA1 {
-                value = "TA_1"
-                scope = local
-                kind = pe
-            }
-            [
-                position = 8296, 8096
+                position = 9272, 8336
                 size = 60, 20
             ]
 
@@ -15900,19 +15906,19 @@ Te_mem = Te;
             connect TagA1 A1 as Connection42
             connect B1 TagB1 as Connection43
             connect TagC1 C1 as Connection44
-            connect T1.sec_2 TagTB2 as Connection68
-            connect T1.sec_3 TagTC2 as Connection69
-            connect A2 TagA2 as Connection72
-            connect TagB2 B2 as Connection73
-            connect C2 TagC2 as Connection74
-            connect T1.n2 Junction1 as Connection79
-            connect TagTN2 Junction1 as Connection81
-            connect TagTA2 T1.sec_1 as Connection84
-            connect T1.prm_2 TagTB1 as Connection86
-            connect TagTC1 T1.prm_3 as Connection87
-            connect T1.n1 N1 as Connection88
-            connect T1.n2 N2 as Connection89
-            connect TagTA1 T1.prm_1 as Connection90
+            connect T1.prm_1 TagTA1 as Connection45
+            connect T1.prm_2 TagTB1 as Connection46
+            connect T1.prm_3 TagTC1 as Connection47
+            connect T1.n1 TagTN1 as Connection48
+            connect T1.sec_1 TagTA2 as Connection49
+            connect T1.sec_2 TagTB2 as Connection50
+            connect T1.sec_3 TagTC2 as Connection51
+            connect T1.n2 TagTN2 as Connection52
+            connect TagA2 A2 as Connection53
+            connect TagB2 B2 as Connection54
+            connect TagC2 C2 as Connection55
+            connect T1.n1 N1 as N1n1
+            connect T1.n2 N2 as N2n2
 
             mask {
                 description = "<html><head><meta name=\"qrichtext\" content=\"1\"></meta><style type=\"text/css\">p, li { white-space: pre-wrap; }</style></head><body style=\"\"><p style=\"margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">The Three-Phase Transfomer is implemented as a multi-terminal power delivery element and consists of two or more windings, with a default wye-wye connection.<br></br><br></br>Note that contrary to OpenDSS, individual reactances are defined in the mask. Reactances between windings will be calculated.</p></body></html>"
@@ -15974,6 +15980,7 @@ Te_mem = Te;
                     type = string
                     default_value = "None"
                     group = "Core coupling"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -15999,6 +16006,7 @@ Te_mem = Te;
                     type = string
                     default_value = "None"
                     group = "Core coupling"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -16024,6 +16032,7 @@ Te_mem = Te;
                     type = string
                     default_value = "None"
                     group = "Core coupling"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -16209,6 +16218,7 @@ Te_mem = Te;
                     type = string
                     default_value = "Y"
                     group = "Winding connections"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -16230,6 +16240,7 @@ Te_mem = Te;
                     type = bool
                     default_value = "False"
                     group = "Winding connections"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -16247,6 +16258,7 @@ Te_mem = Te;
                     type = string
                     default_value = "Y"
                     group = "Winding connections"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -16268,6 +16280,7 @@ Te_mem = Te;
                     type = bool
                     default_value = "False"
                     group = "Winding connections"
+                    nonvisible
                     no_evaluate
 
                     CODE property_value_changed
@@ -16425,6 +16438,7 @@ Te_mem = Te;
                     type = bool
                     default_value = "False"
                     group = "Monitoring:5"
+                    no_evaluate
                 }
 
                 CODE open
@@ -16726,8 +16740,8 @@ Te_mem = Te;
                     type = string
                     default_value = "Generate"
                     group = "Report:3"
-                    no_evaluate
                     nonvisible
+                    no_evaluate
 
                     CODE button_clicked
                         comp_script = return_comp_script(mdl, container_handle)
@@ -16854,10 +16868,10 @@ Te_mem = Te;
         component Subsystem Isource {
             layout = static
             label = "I"
-            component src_current Ia {
-                init_frequency = "60"
-                init_phase = "0"
-                init_rms_value = "0"
+            component "core/Current Source" Ia {
+                init_frequency = "Frequency"
+                init_phase = "Angle - 0"
+                init_rms_value = "amps"
                 init_source_nature = "Sine"
             }
             [
@@ -16865,10 +16879,10 @@ Te_mem = Te;
                 rotation = down
             ]
 
-            component src_current Ib {
-                init_frequency = "60"
-                init_phase = "-120"
-                init_rms_value = "0"
+            component "core/Current Source" Ib {
+                init_frequency = "Frequency"
+                init_phase = "Angle - 120"
+                init_rms_value = "amps"
                 init_source_nature = "Sine"
             }
             [
@@ -16876,10 +16890,10 @@ Te_mem = Te;
                 rotation = down
             ]
 
-            component src_current Ic {
-                init_frequency = "60"
-                init_phase = "-240"
-                init_rms_value = "0"
+            component "core/Current Source" Ic {
+                init_frequency = "Frequency"
+                init_phase = "Angle - 240"
+                init_rms_value = "amps"
                 init_source_nature = "Sine"
             }
             [
@@ -16887,7 +16901,7 @@ Te_mem = Te;
                 rotation = down
             ]
 
-            component src_ground gnd1 {
+            component "core/Ground" gnd1 {
             }
             [
                 position = 8000, 8400
@@ -17006,6 +17020,7 @@ Te_mem = Te;
                     type = bool
                     default_value = "False"
                     group = "Monitoring"
+                    no_evaluate
                 }
 
                 CODE open
@@ -17145,7 +17160,7 @@ Te_mem = Te;
         component Subsystem "Capacitor Bank" {
             layout = static
             label = "C"
-            component pas_capacitor Ca {
+            component "core/Capacitor" Ca {
                 capacitance = "C"
             }
             [
@@ -17153,7 +17168,7 @@ Te_mem = Te;
                 rotation = down
             ]
 
-            component pas_capacitor Cb {
+            component "core/Capacitor" Cb {
                 capacitance = "C"
             }
             [
@@ -17161,7 +17176,7 @@ Te_mem = Te;
                 rotation = down
             ]
 
-            component pas_capacitor Cc {
+            component "core/Capacitor" Cc {
                 capacitance = "C"
             }
             [
@@ -17170,7 +17185,7 @@ Te_mem = Te;
             ]
 
             port A1 {
-                position = -32.0, -32.0
+                position = -32, -32
                 kind = pe
             }
             [
@@ -17179,7 +17194,7 @@ Te_mem = Te;
             ]
 
             port B1 {
-                position = 0.0, -32.0
+                position = 0, -32
                 kind = pe
             }
             [
@@ -17188,7 +17203,7 @@ Te_mem = Te;
             ]
 
             port C1 {
-                position = 32.0, -32.0
+                position = 32, -32
                 kind = pe
             }
             [
@@ -17202,11 +17217,11 @@ Te_mem = Te;
             ]
 
             connect Ca.p_node A1 as Connection26
-            connect Cc.p_node C1 as c1_conn
-            connect j Ca.n_node as Connection28
-            connect j Cb.n_node as Connection29
-            connect j Cc.n_node as Connection30
+            connect j Ca.n_node as Connection27
+            connect j Cb.n_node as Connection28
+            connect j Cc.n_node as Connection29
             connect B1 Cb.p_node as b1_conn
+            connect Cc.p_node C1 as Connection30
 
             mask {
                 description = "<html><head><meta name=\"qrichtext\" content=\"1\"></meta><style type=\"text/css\">p, li { white-space: pre-wrap; }</style></head><body style=\"\"><p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><br>Three-Phase Capacitor Bank.</br></p></body></html>"
@@ -17314,6 +17329,7 @@ Te_mem = Te;
                     type = bool
                     default_value = "False"
                     group = "Monitoring"
+                    no_evaluate
                 }
 
                 CODE open
@@ -17370,8 +17386,7 @@ Te_mem = Te;
 
         component Subsystem Storage {
             layout = static
-
-            component src_constant chtrigger {
+            component "core/Constant" chtrigger {
                 execution_rate = "execution_rate"
                 value = "chargetrigger"
             }
@@ -17379,7 +17394,7 @@ Te_mem = Te;
                 position = 8128, 7440
             ]
 
-            component src_constant dchtrigger {
+            component "core/Constant" dchtrigger {
                 execution_rate = "execution_rate"
                 value = "dischargetrigger"
             }
@@ -17387,7 +17402,7 @@ Te_mem = Te;
                 position = 8200, 7392
             ]
 
-            component gen_c_function "Dispatch kW Reference Calculation" {
+            component "core/C function" "Dispatch kW Reference Calculation" {
                 input_terminals = "real loadshape_point;inherit kwrated;real dchtrigger;real chtrigger;int dispatch_mode;real pct_charge;real pct_discharge;"
                 input_terminals_dimensions = "inherit;inherit;inherit;inherit;inherit;inherit;inherit"
                 input_terminals_feedthrough = "True;True;True;True;True;True;True"
@@ -17437,7 +17452,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                 size = 280, 368
             ]
 
-            component gen_probe "Enable Inverter" {
+            component "core/Probe" "Enable Inverter" {
             }
             [
                 position = 8632, 7344
@@ -17473,14 +17488,14 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                 layout = dynamic
                 component Subsystem "kvar calculation" {
                     layout = dynamic
-                    component sys_mp_signal_switch kVAr {
+                    component "core/Multiport signal switch" kVAr {
                         number_of_input_terminals = "6"
                     }
                     [
                         position = 8872, 8240
                     ]
 
-                    component src_constant "unit pf" {
+                    component "core/Constant" "unit pf" {
                         execution_rate = "execution_rate"
                         value = "0"
                     }
@@ -17488,7 +17503,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                         position = 8664, 8208
                     ]
 
-                    component src_constant kvar_kvar {
+                    component "core/Constant" kvar_kvar {
                         execution_rate = "execution_rate"
                         value = "kvar*1000"
                     }
@@ -17496,14 +17511,14 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                         position = 8664, 8352
                     ]
 
-                    component gen_gain Gain1 {
+                    component "core/Gain" Gain1 {
                         gain = "np.sqrt(1/(pf*pf)-1)"
                     }
                     [
                         position = 8752, 8272
                     ]
 
-                    component src_constant kwrated {
+                    component "core/Constant" kwrated {
                         execution_rate = "execution_rate"
                         value = "kwrated*1000"
                     }
@@ -17579,26 +17594,26 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     size = 120, 80
                 ]
 
-                component gen_product Product16 {
+                component "core/Product" Product16 {
                     signs = "/*"
                 }
                 [
                     position = 7280, 7760
                 ]
 
-                component gen_product Product18 {
+                component "core/Product" Product18 {
                 }
                 [
                     position = 6976, 7864
                 ]
 
-                component gen_product Product19 {
+                component "core/Product" Product19 {
                 }
                 [
                     position = 7168, 7680
                 ]
 
-                component src_constant vmax {
+                component "core/Constant" vmax {
                     execution_rate = "execution_rate"
                     value = "kv*1000*vmaxpu"
                 }
@@ -17606,7 +17621,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     position = 6928, 7648
                 ]
 
-                component src_constant vmin {
+                component "core/Constant" vmin {
                     execution_rate = "execution_rate"
                     value = "kv*1000*vminpu"
                 }
@@ -17614,28 +17629,26 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     position = 6928, 7712
                 ]
 
-                component sys_signal_switch "Signal switch4" {
-                    criterion = "ctrl > threshold"
+                component "core/Signal switch" "Signal switch4" {
                     threshold = "kv*1000"
                 }
                 [
                     position = 7024, 7680
                 ]
 
-                component gen_product Product20 {
+                component "core/Product" Product20 {
                 }
                 [
                     position = 7672, 7912
                 ]
 
-                component gen_product Product21 {
+                component "core/Product" Product21 {
                 }
                 [
                     position = 7672, 8040
                 ]
 
-                component sys_signal_switch "Signal switch2" {
-                    criterion = "ctrl > threshold"
+                component "core/Signal switch" "Signal switch2" {
                     threshold = "0.1"
                 }
                 [
@@ -17644,7 +17657,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
 
                 component Subsystem "Constant Z mode check" {
                     layout = dynamic
-                    component src_constant vmaxpu {
+                    component "core/Constant" vmaxpu {
                         execution_rate = "execution_rate"
                         value = "vmaxpu*kv*1000"
                     }
@@ -17652,7 +17665,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                         position = 8088, 8152
                     ]
 
-                    component src_constant vminpu {
+                    component "core/Constant" vminpu {
                         execution_rate = "execution_rate"
                         value = "vminpu*kv*1000"
                     }
@@ -17660,21 +17673,21 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                         position = 8088, 8248
                     ]
 
-                    component gen_rel_op "Relational operator1" {
+                    component "core/Relational operator" "Relational operator1" {
                         relational_op = ">"
                     }
                     [
                         position = 8184, 8144
                     ]
 
-                    component gen_rel_op "Relational operator2" {
+                    component "core/Relational operator" "Relational operator2" {
                         relational_op = "<"
                     }
                     [
                         position = 8184, 8240
                     ]
 
-                    component gen_logic_op "Logical operator1" {
+                    component "core/Logical operator" "Logical operator1" {
                         operator = "OR"
                     }
                     [
@@ -17730,28 +17743,27 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     size = 152, 88
                 ]
 
-                component gen_probe ctZ {
+                component "core/Probe" ctZ {
                 }
                 [
                     position = 7496, 7520
                 ]
 
-                component src_constant const_p_mult {
+                component "core/Constant" const_p_mult {
                     execution_rate = "execution_rate"
                 }
                 [
                     position = 7344, 7840
                 ]
 
-                component sys_signal_switch "Signal switch3" {
-                    criterion = "ctrl > threshold"
+                component "core/Signal switch" "Signal switch3" {
                     threshold = "0.1"
                 }
                 [
                     position = 7880, 7928
                 ]
 
-                component src_constant Constant1 {
+                component "core/Constant" Constant1 {
                     execution_rate = "execution_rate"
                     value = "-pct_idlingkw/100*kwrated*1000"
                 }
@@ -17759,19 +17771,19 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     position = 7776, 7944
                 ]
 
-                component gen_probe ctz_multiplier {
+                component "core/Probe" ctz_multiplier {
                 }
                 [
                     position = 7392, 7696
                 ]
 
-                component gen_data_type_conversion "Data Type Conversion1" {
+                component "core/Data Type Conversion" "Data Type Conversion1" {
                 }
                 [
                     position = 7784, 8040
                 ]
 
-                component gen_limiter Limit1 {
+                component "core/Limit" Limit1 {
                     lower_limit = "[-4*kwrated*1000]"
                     upper_limit = "[4*kwrated*1000]"
                 }
@@ -17779,23 +17791,22 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     position = 7968, 7928
                 ]
 
-                component gen_bus_join "Bus Join1" {
+                component "core/Bus Join" "Bus Join1" {
                     inputs = "3"
                 }
                 [
                     position = 8216, 7984
                 ]
 
-                component gen_probe "Inverter P Reference" {
+                component "core/Probe" "Inverter P Reference" {
                 }
                 [
                     position = 8056, 7888
                     rotation = left
                 ]
 
-                component src_constant enable_inverter {
+                component "core/Constant" enable_inverter {
                     execution_rate = "execution_rate"
-                    _tunable = "False"
                 }
                 [
                     position = 8280, 7912
@@ -17803,7 +17814,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     scale = 1, -1
                 ]
 
-                component gen_probe "Inverter Q Reference" {
+                component "core/Probe" "Inverter Q Reference" {
                 }
                 [
                     position = 8056, 8112
@@ -18014,14 +18025,14 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                 size = 144, 176
             ]
 
-            component gen_probe Vline {
+            component "core/Probe" Vline {
             }
             [
                 position = 7472, 7872
                 rotation = left
             ]
 
-            component gen_probe "DSS kW Reference" {
+            component "core/Probe" "DSS kW Reference" {
             }
             [
                 position = 8632, 7528
@@ -18038,13 +18049,13 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
 
             component Subsystem "Active status" {
                 layout = dynamic
-                component gen_data_type_conversion bool_to_real {
+                component "core/Data Type Conversion" bool_to_real {
                 }
                 [
                     position = 8296, 8192
                 ]
 
-                component gen_logic_op "Logical operator1" {
+                component "core/Logical operator" "Logical operator1" {
                 }
                 [
                     position = 8192, 8192
@@ -18099,7 +18110,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                 size = 104, 96
             ]
 
-            component gen_probe "Battery Active" {
+            component "core/Probe" "Battery Active" {
             }
             [
                 position = 7864, 7632
@@ -18116,14 +18127,14 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
 
             component Subsystem "Ch | Dch Losses Current Calc" {
                 layout = dynamic
-                component sys_signal_switch "Signal switch3" {
-                    criterion = "ctrl > threshold"
+                component "core/Signal switch" "Signal switch3" {
+                    threshold = "0"
                 }
                 [
                     position = 8240, 8192
                 ]
 
-                component src_constant charge_losses {
+                component "core/Constant" charge_losses {
                     execution_rate = "execution_rate"
                     value = "1-pct_effcharge/100"
                 }
@@ -18131,7 +18142,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     position = 8056, 8120
                 ]
 
-                component src_constant discharge_losses {
+                component "core/Constant" discharge_losses {
                     execution_rate = "execution_rate"
                     value = "1-pct_effdischarge/100"
                 }
@@ -18139,19 +18150,19 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     position = 8064, 8264
                 ]
 
-                component gen_product Power1 {
+                component "core/Product" Power1 {
                 }
                 [
                     position = 8488, 8208
                 ]
 
-                component gen_abs Abs1 {
+                component "core/Abs" Abs1 {
                 }
                 [
                     position = 8064, 8400
                 ]
 
-                component sys_signal_switch "Signal switch4" {
+                component "core/Signal switch" "Signal switch4" {
                     criterion = "ctrl > threshold"
                     threshold = "0.5"
                 }
@@ -18159,7 +18170,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     position = 8904, 8240
                 ]
 
-                component src_constant Constant1 {
+                component "core/Constant" Constant1 {
                     execution_rate = "execution_rate"
                     value = "0"
                 }
@@ -18274,19 +18285,19 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                 size = 88, 200
             ]
 
-            component gen_probe P {
+            component "core/Probe" P {
             }
             [
                 position = 7464, 7984
             ]
 
-            component gen_probe Q {
+            component "core/Probe" Q {
             }
             [
                 position = 7488, 8032
             ]
 
-            component gen_probe pf {
+            component "core/Probe" pf {
             }
             [
                 position = 7520, 8080
@@ -18294,7 +18305,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
 
             component Subsystem "Dispatch Mode Integer" {
                 layout = dynamic
-                component src_constant kw_mode {
+                component "core/Constant" kw_mode {
                     execution_rate = "execution_rate"
                     signal_type = "int"
                     value = "dispatch_mode_int"
@@ -18352,7 +18363,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                 size = 152, 56
             ]
 
-            component src_constant pct_charge {
+            component "core/Constant" pct_charge {
                 execution_rate = "execution_rate"
                 value = "pct_charge"
             }
@@ -18360,7 +18371,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                 position = 8128, 7536
             ]
 
-            component src_constant pct_discharge {
+            component "core/Constant" pct_discharge {
                 execution_rate = "execution_rate"
                 value = "pct_discharge"
             }
@@ -18368,7 +18379,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                 position = 8200, 7584
             ]
 
-            component src_constant kwrated {
+            component "core/Constant" kwrated {
                 execution_rate = "execution_rate"
                 value = "kwrated"
             }
@@ -18384,7 +18395,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                 size = 64, 32
             ]
 
-            component src_constant Vdc {
+            component "core/Constant" Vdc {
                 execution_rate = "execution_rate"
                 value = "4*kv*1000*vmaxpu"
             }
@@ -18393,7 +18404,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                 scale = -1, 1
             ]
 
-            component pas_resistor R1 {
+            component "core/Resistor" R1 {
                 resistance = "(4*kv*1000*vmaxpu)**2/(pct_idlingkw/100*kwrated*1000 + 1e-6)"
             }
             [
@@ -18403,7 +18414,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
 
             component Subsystem "Battery Energy" {
                 layout = dynamic
-                component gen_integrator Energy {
+                component "core/Integrator" Energy {
                     init_value = "pct_stored/100*kwhrated*1000"
                     limit_lower = "kwhrated*1000*pct_reserve/100"
                     limit_output = "True"
@@ -18413,40 +18424,38 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     position = 8312, 8248
                 ]
 
-                component gen_probe SOC {
+                component "core/Probe" SOC {
                 }
                 [
                     position = 8504, 8184
                 ]
 
-                component gen_product Power {
+                component "core/Product" Power {
                 }
                 [
                     position = 7888, 8224
                 ]
 
-                component gen_gain Gain3 {
+                component "core/Gain" Gain3 {
                     gain = "100/(kwhrated*1000)"
                 }
                 [
                     position = 8424, 8184
                 ]
 
-                component gen_probe "Battery Power" {
+                component "core/Probe" "Battery Power" {
                 }
                 [
                     position = 8016, 8048
                 ]
 
-                component sys_signal_switch "Signal switch3" {
-                    criterion = "ctrl > threshold"
-                    threshold = "0.5"
+                component "core/Signal switch" "Signal switch3" {
                 }
                 [
                     position = 8016, 8240
                 ]
 
-                component src_constant Constant1 {
+                component "core/Constant" Constant1 {
                     execution_rate = "execution_rate"
                     value = "0"
                 }
@@ -18454,7 +18463,7 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     position = 7920, 8288
                 ]
 
-                component src_step Step1 {
+                component "core/Step" Step1 {
                     execution_rate = "execution_rate"
                     step_time = "0.5"
                 }
@@ -18462,13 +18471,13 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                     position = 8032, 8336
                 ]
 
-                component gen_product "E meas sw" {
+                component "core/Product" "E meas sw" {
                 }
                 [
                     position = 8136, 8248
                 ]
 
-                component gen_gain Gain4 {
+                component "core/Gain" Gain4 {
                     gain = "1/3600"
                 }
                 [
@@ -18591,14 +18600,14 @@ else if (dispatch_mode == 4 || dispatch_mode == 5 || dispatch_mode == 6){
                 size = 64, 32
             ]
 
-            component gen_sum Sum1 {
+            component "core/Sum" Sum1 {
                 signs = "+-"
             }
             [
                 position = 8088, 8080
             ]
 
-            component gen_c_function "Disconnect if on reserve or charged" {
+            component "core/C function" "Disconnect if on reserve or charged" {
                 input_terminals = "real energy;inherit kwhrated;inherit pct_reserve;inherit kwref;inherit active_inverter;"
                 input_terminals_dimensions = "inherit;inherit;inherit;inherit;inherit"
                 input_terminals_feedthrough = "True;True;True;True;True"
@@ -18639,7 +18648,7 @@ else{
                 size = 216, 280
             ]
 
-            component src_constant kwhrated {
+            component "core/Constant" kwhrated {
                 execution_rate = "execution_rate"
                 value = "kwhrated"
             }
@@ -18647,7 +18656,7 @@ else{
                 position = 7352, 7344
             ]
 
-            component src_constant pct_reserve {
+            component "core/Constant" pct_reserve {
                 execution_rate = "execution_rate"
                 value = "pct_reserve"
             }
@@ -18655,7 +18664,7 @@ else{
                 position = 7352, 7400
             ]
 
-            component gen_terminator Termination2 {
+            component "core/Termination" Termination2 {
             }
             [
                 position = 7656, 8160
@@ -18664,7 +18673,7 @@ else{
 
             component Subsystem "Loadshape Point Selector" {
                 layout = dynamic
-                component src_constant loadshape {
+                component "core/Constant" loadshape {
                     execution_rate = "execution_rate"
                     value = "loadshape"
                 }
@@ -18672,7 +18681,7 @@ else{
                     position = 8200, 8144
                 ]
 
-                component gen_c_function Selector {
+                component "core/C function" Selector {
                     global_variables = "real out_value;"
                     input_terminals = "real loadshape;int point;"
                     input_terminals_dimensions = "inherit;inherit"
@@ -18704,7 +18713,7 @@ out = out_value;
                     size = 168, 168
                 ]
 
-                component gen_probe "Loadshape Value" {
+                component "core/Probe" "Loadshape Value" {
                 }
                 [
                     position = 8528, 8096
@@ -19189,8 +19198,8 @@ out = out_value;
                     widget = checkbox
                     type = bool
                     default_value = "True"
-                    no_evaluate
                     group = "Ratings:2"
+                    no_evaluate
 
                     CODE property_value_edited
                         comp_script = return_comp_script(mdl, container_handle)
@@ -19386,8 +19395,8 @@ out = out_value;
                     widget = edit
                     type = generic
                     default_value = ""
-                    no_evaluate
                     nonvisible
+                    no_evaluate
                 }
 
                 loadshape_from_file_column {
@@ -19395,8 +19404,8 @@ out = out_value;
                     widget = edit
                     type = generic
                     default_value = "1"
-                    no_evaluate
                     nonvisible
+                    no_evaluate
                 }
 
                 loadshape_from_file_header {
@@ -19404,8 +19413,8 @@ out = out_value;
                     widget = checkbox
                     type = generic
                     default_value = "True"
-                    no_evaluate
                     nonvisible
+                    no_evaluate
                 }
 
                 loadshape {
@@ -19441,6 +19450,7 @@ out = out_value;
                     type = string
                     default_value = "Daily"
                     nonvisible
+                    no_evaluate
                 }
 
                 pct_stored {
@@ -19546,6 +19556,7 @@ out = out_value;
                     type = bool
                     default_value = "False"
                     group = "Monitoring"
+                    no_evaluate
                 }
 
 
@@ -19656,8 +19667,7 @@ out = out_value;
 
         component Subsystem "Co-simulation Interface" {
             layout = dynamic
-            label = "CoSim"
-            component src_constant f {
+            component "core/Constant" f {
                 execution_rate = "execution_rate"
                 value = "f"
             }
@@ -19666,13 +19676,13 @@ out = out_value;
                 hide_name = True
             ]
 
-            component src_ground gnd1 {
+            component "core/Ground" gnd1 {
             }
             [
                 position = 1224, 9248
             ]
 
-            component src_sine "vref" {
+            component "core/Sinusoidal Source" vref {
                 amplitude = "100"
                 execution_rate = "execution_rate"
                 frequency = "f"
@@ -19718,11 +19728,13 @@ out = out_value;
 
             connect Goto1 f.out as Connection52
             [
+                position = 0, 0
                 hide_name = True
             ]
             connect gnd_tag gnd1.node as Connection127
-            connect "vref.out" Goto2 as Connection128
+            connect vref.out Goto2 as Connection128
             [
+                position = 0, 0
                 hide_name = True
             ]
 
@@ -21976,27 +21988,27 @@ out = out_value;
 
             component Subsystem TS_module {
                 layout = dynamic
-                component src_clock Clock1 {
+                component "core/Clock" Clock1 {
                     execution_rate = "Texec"
                 }
                 [
                     position = 6824, 8000
                 ]
 
-                component gen_probe d_rel {
+                component "core/Probe" d_rel {
                     signal_name = "Delay release"
                 }
                 [
                     position = 6928, 7936
                 ]
 
-                component gen_comparator Comparator1 {
+                component "core/Comparator" Comparator1 {
                 }
                 [
                     position = 6928, 8000
                 ]
 
-                component src_constant Constant1 {
+                component "core/Constant" Constant1 {
                     execution_rate = "Texec"
                     value = "Tdel"
                 }
@@ -22004,21 +22016,22 @@ out = out_value;
                     position = 6824, 8064
                 ]
 
-                component sys_signal_switch "Signal switch1" {
+                component "core/Signal switch" "Signal switch1" {
                     criterion = "ctrl >= threshold"
+                    threshold = "0.5"
                 }
                 [
                     position = 7008, 8144
                 ]
 
-                component src_constant Constant3 {
+                component "core/Constant" Constant3 {
                     execution_rate = "Texec"
                 }
                 [
                     position = 6840, 8128
                 ]
 
-                component gen_integrator Integrator1 {
+                component "core/Integrator" Integrator1 {
                     show_reset = "rising"
                     show_state = "True"
                 }
@@ -22026,7 +22039,7 @@ out = out_value;
                     position = 7352, 8152
                 ]
 
-                component src_constant Constant4 {
+                component "core/Constant" Constant4 {
                     execution_rate = "Texec"
                     value = "Tmax"
                 }
@@ -22034,13 +22047,13 @@ out = out_value;
                     position = 7152, 8304
                 ]
 
-                component gen_comparator Comparator2 {
+                component "core/Comparator" Comparator2 {
                 }
                 [
                     position = 7240, 8296
                 ]
 
-                component lut_1d "1D look-up table1" {
+                component "core/1D look-up table" "1D look-up table1" {
                     in_vec_x = "T_vecP"
                     out_vec_f_x = "P_vec1"
                 }
@@ -22048,7 +22061,7 @@ out = out_value;
                     position = 7608, 8008
                 ]
 
-                component lut_1d "1D look-up table2" {
+                component "core/1D look-up table" "1D look-up table2" {
                     in_vec_x = "T_vecQ"
                     out_vec_f_x = "Q_vec1"
                 }
@@ -22056,7 +22069,7 @@ out = out_value;
                     position = 7608, 8192
                 ]
 
-                component src_constant Constant5 {
+                component "core/Constant" Constant5 {
                     execution_rate = "Texec"
                     value = "0"
                 }
@@ -22064,14 +22077,15 @@ out = out_value;
                     position = 6840, 8176
                 ]
 
-                component sys_signal_switch "Signal switch2" {
+                component "core/Signal switch" "Signal switch2" {
                     criterion = "ctrl >= threshold"
+                    threshold = "0.5"
                 }
                 [
                     position = 7176, 8144
                 ]
 
-                component src_constant Constant6 {
+                component "core/Constant" Constant6 {
                     execution_rate = "Texec"
                     value = "loop_en"
                 }
@@ -22079,14 +22093,15 @@ out = out_value;
                     position = 7112, 8048
                 ]
 
-                component sys_signal_switch "Signal switch3" {
+                component "core/Signal switch" "Signal switch3" {
                     criterion = "ctrl >= threshold"
+                    threshold = "0.5"
                 }
                 [
                     position = 7456, 8160
                 ]
 
-                component src_constant Constant7 {
+                component "core/Constant" Constant7 {
                     execution_rate = "Texec"
                     value = "loop_en"
                 }
@@ -22094,7 +22109,7 @@ out = out_value;
                     position = 7400, 8064
                 ]
 
-                component gen_gain Gain1 {
+                component "core/Gain" Gain1 {
                 }
                 [
                     position = 7384, 8352
@@ -22475,7 +22490,7 @@ out = out_value;
                 layout = dynamic
                 component Subsystem Auto1 {
                     layout = static
-                    component el_current_msr Isec_A {
+                    component "core/el_current_msr" Isec_A {
                         execution_rate = "execution_rate"
                         sig_output = "True"
                     }
@@ -22483,21 +22498,21 @@ out = out_value;
                         position = 9256, 8656
                     ]
 
-                    component pas_inductor Lr_A {
+                    component "core/Inductor" Lr_A {
                         inductance = "Lright"
                     }
                     [
                         position = 8896, 8656
                     ]
 
-                    component pas_resistor Rr_A {
+                    component "core/Resistor" Rr_A {
                         resistance = "Rright"
                     }
                     [
                         position = 8800, 8656
                     ]
 
-                    component pas_inductor Lm_A {
+                    component "core/Inductor" Lm_A {
                         inductance = "Lm"
                     }
                     [
@@ -22505,7 +22520,7 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_resistor Rm_A {
+                    component "core/Resistor" Rm_A {
                         resistance = "Rm"
                     }
                     [
@@ -22513,14 +22528,14 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_inductor Ll_A {
+                    component "core/Inductor" Ll_A {
                         inductance = "Lleft"
                     }
                     [
                         position = 8160, 8656
                     ]
 
-                    component pas_resistor Rl_A {
+                    component "core/Resistor" Rl_A {
                         resistance = "Rleft"
                     }
                     [
@@ -22529,7 +22544,7 @@ out = out_value;
 
                     component Subsystem "Elapsed Time" {
                         layout = dynamic
-                        component src_clock Clock1 {
+                        component "core/Clock" Clock1 {
                             execution_rate = "execution_rate"
                         }
                         [
@@ -22537,15 +22552,16 @@ out = out_value;
                             hide_name = True
                         ]
 
-                        component sys_signal_switch "Signal switch1" {
+                        component "core/Signal switch" "Signal switch1" {
                             criterion = "ctrl >= threshold"
+                            threshold = "0.5"
                         }
                         [
                             position = 8200, 8184
                             hide_name = True
                         ]
 
-                        component tm_delay "Unit Delay1" {
+                        component "core/Unit Delay" "Unit Delay1" {
                         }
                         [
                             position = 8200, 8240
@@ -22563,7 +22579,7 @@ out = out_value;
                             size = 32, 32
                         ]
 
-                        component gen_sum Sum2 {
+                        component "core/Sum" Sum2 {
                             signs = "-+"
                         }
                         [
@@ -22631,7 +22647,7 @@ out = out_value;
                         size = 48, 48
                     ]
 
-                    component src_constant var_per_tap {
+                    component "core/Constant" var_per_tap {
                         execution_rate = "execution_rate"
                         value = "var_per_tap"
                     }
@@ -22639,14 +22655,14 @@ out = out_value;
                         position = 8936, 8328
                     ]
 
-                    component gen_product Product1 {
+                    component "core/Product" Product1 {
                     }
                     [
                         position = 9040, 8264
                         hide_name = True
                     ]
 
-                    component gen_probe tap {
+                    component "core/Probe" tap {
                     }
                     [
                         position = 9112, 8184
@@ -22654,7 +22670,7 @@ out = out_value;
                         scale = -1, -1
                     ]
 
-                    component src_constant regulator_voltage {
+                    component "core/Constant" regulator_voltage {
                         execution_rate = "execution_rate"
                         value = "Vreg"
                     }
@@ -22663,7 +22679,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component src_constant regulator_voltage1 {
+                    component "core/Constant" regulator_voltage1 {
                         execution_rate = "execution_rate"
                         value = "band"
                     }
@@ -22672,7 +22688,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_gain Gain1 {
+                    component "core/Gain" Gain1 {
                         gain = "0.5"
                     }
                     [
@@ -22680,7 +22696,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_sum VSum {
+                    component "core/Sum" VSum {
                         signs = "-+"
                     }
                     [
@@ -22688,21 +22704,21 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_abs Abs1 {
+                    component "core/Abs" Abs1 {
                     }
                     [
                         position = 8032, 8248
                         hide_name = True
                     ]
 
-                    component gen_sign Sign1 {
+                    component "core/Sign" Sign1 {
                     }
                     [
                         position = 8032, 8208
                         hide_name = True
                     ]
 
-                    component src_constant regulator_voltage2 {
+                    component "core/Constant" regulator_voltage2 {
                         execution_rate = "execution_rate"
                         value = "Td"
                     }
@@ -22711,7 +22727,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_rel_op "Relational operator2" {
+                    component "core/Relational operator" "Relational operator2" {
                         relational_op = ">"
                     }
                     [
@@ -22719,7 +22735,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_logic_op "Logical operator1" {
+                    component "core/Logical operator" "Logical operator1" {
                     }
                     [
                         position = 8672, 8288
@@ -22735,14 +22751,14 @@ out = out_value;
                         size = 32, 32
                     ]
 
-                    component gen_logic_op "Logical operator2" {
+                    component "core/Logical operator" "Logical operator2" {
                     }
                     [
                         position = 8448, 8280
                         hide_name = True
                     ]
 
-                    component gen_logic_op "Logical operator3" {
+                    component "core/Logical operator" "Logical operator3" {
                         operator = "NOT"
                     }
                     [
@@ -22751,7 +22767,7 @@ out = out_value;
                         scale = -1, 1
                     ]
 
-                    component gen_product Product2 {
+                    component "core/Product" Product2 {
                     }
                     [
                         position = 8752, 8256
@@ -22776,7 +22792,7 @@ out = out_value;
                         size = 64, 32
                     ]
 
-                    component gen_gain ABcomp {
+                    component "core/Gain" ABcomp {
                         gain = "ABcomp"
                     }
                     [
@@ -22785,7 +22801,7 @@ out = out_value;
                         scale = -1, 1
                     ]
 
-                    component gen_accumulator "Tap Position" {
+                    component "core/Accumulator" "Tap Position" {
                         limit_lower = "-min_n_tap"
                         limit_output = "True"
                         limit_upper = "max_n_tap"
@@ -22794,7 +22810,7 @@ out = out_value;
                         position = 8832, 8256
                     ]
 
-                    component el_voltage_msr Vprim_A {
+                    component "core/el_voltage_msr" Vprim_A {
                         execution_rate = "execution_rate"
                         sig_output = "True"
                     }
@@ -22803,7 +22819,7 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component gen_gain Gain4 {
+                    component "core/Gain" Gain4 {
                         gain = "1/ptratio_auto"
                     }
                     [
@@ -22827,19 +22843,19 @@ out = out_value;
                         size = 64, 32
                     ]
 
-                    component gen_product Product11 {
+                    component "core/Product" Product11 {
                     }
                     [
                         position = 8312, 8872
                     ]
 
-                    component gen_product Product10 {
+                    component "core/Product" Product10 {
                     }
                     [
                         position = 8312, 8968
                     ]
 
-                    component gen_probe per_tap {
+                    component "core/Probe" per_tap {
                     }
                     [
                         position = 9040, 8328
@@ -22847,7 +22863,7 @@ out = out_value;
                         scale = -1, -1
                     ]
 
-                    component gen_probe pu_applied {
+                    component "core/Probe" pu_applied {
                     }
                     [
                         position = 9344, 8192
@@ -22855,7 +22871,7 @@ out = out_value;
                         scale = -1, -1
                     ]
 
-                    component gen_sum VSum1 {
+                    component "core/Sum" VSum1 {
                         signs = "++"
                     }
                     [
@@ -22863,7 +22879,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component src_constant regulator_voltage3 {
+                    component "core/Constant" regulator_voltage3 {
                         execution_rate = "execution_rate"
                     }
                     [
@@ -22871,7 +22887,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_sum VSum2 {
+                    component "core/Sum" VSum2 {
                         signs = "-+"
                     }
                     [
@@ -22879,7 +22895,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component src_constant regulator_voltage4 {
+                    component "core/Constant" regulator_voltage4 {
                         execution_rate = "execution_rate"
                         value = "tap_difference"
                     }
@@ -22888,7 +22904,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component el_current_msr Isec_B {
+                    component "core/el_current_msr" Isec_B {
                         execution_rate = "execution_rate"
                         sig_output = "True"
                     }
@@ -22896,21 +22912,21 @@ out = out_value;
                         position = 9264, 9136
                     ]
 
-                    component pas_inductor Lr_B {
+                    component "core/Inductor" Lr_B {
                         inductance = "Lright"
                     }
                     [
                         position = 8904, 9136
                     ]
 
-                    component pas_resistor Rr_B {
+                    component "core/Resistor" Rr_B {
                         resistance = "Rright"
                     }
                     [
                         position = 8808, 9136
                     ]
 
-                    component pas_inductor Lm_B {
+                    component "core/Inductor" Lm_B {
                         inductance = "Lm"
                     }
                     [
@@ -22918,7 +22934,7 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_resistor Rm_B {
+                    component "core/Resistor" Rm_B {
                         resistance = "Rm"
                     }
                     [
@@ -22926,14 +22942,14 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_inductor Ll_B {
+                    component "core/Inductor" Ll_B {
                         inductance = "Lleft"
                     }
                     [
                         position = 8176, 9136
                     ]
 
-                    component pas_resistor Rl_B {
+                    component "core/Resistor" Rl_B {
                         resistance = "Rleft"
                     }
                     [
@@ -22957,7 +22973,7 @@ out = out_value;
                         size = 64, 32
                     ]
 
-                    component el_voltage_msr Vprim_B {
+                    component "core/el_voltage_msr" Vprim_B {
                         execution_rate = "execution_rate"
                         sig_output = "True"
                     }
@@ -22982,7 +22998,7 @@ out = out_value;
                         size = 64, 32
                     ]
 
-                    component el_current_msr Isec_C {
+                    component "core/el_current_msr" Isec_C {
                         execution_rate = "execution_rate"
                         sig_output = "True"
                     }
@@ -22990,21 +23006,21 @@ out = out_value;
                         position = 9272, 9560
                     ]
 
-                    component pas_inductor Lr_C {
+                    component "core/Inductor" Lr_C {
                         inductance = "Lright"
                     }
                     [
                         position = 8912, 9560
                     ]
 
-                    component pas_resistor Rr_C {
+                    component "core/Resistor" Rr_C {
                         resistance = "Rright"
                     }
                     [
                         position = 8816, 9560
                     ]
 
-                    component pas_inductor Lm_C {
+                    component "core/Inductor" Lm_C {
                         inductance = "Lm"
                     }
                     [
@@ -23012,7 +23028,7 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_resistor Rm_C {
+                    component "core/Resistor" Rm_C {
                         resistance = "Rm"
                     }
                     [
@@ -23020,14 +23036,14 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_inductor Ll_C {
+                    component "core/Inductor" Ll_C {
                         inductance = "Lleft"
                     }
                     [
                         position = 8184, 9560
                     ]
 
-                    component pas_resistor Rl_C {
+                    component "core/Resistor" Rl_C {
                         resistance = "Rleft"
                     }
                     [
@@ -23051,7 +23067,7 @@ out = out_value;
                         size = 64, 32
                     ]
 
-                    component el_voltage_msr Vprim_C {
+                    component "core/el_voltage_msr" Vprim_C {
                         execution_rate = "execution_rate"
                         sig_output = "True"
                     }
@@ -23076,31 +23092,31 @@ out = out_value;
                         size = 64, 32
                     ]
 
-                    component gen_product Product12 {
+                    component "core/Product" Product12 {
                     }
                     [
                         position = 8312, 9344
                     ]
 
-                    component gen_product Product13 {
+                    component "core/Product" Product13 {
                     }
                     [
                         position = 8312, 9440
                     ]
 
-                    component gen_product Product14 {
+                    component "core/Product" Product14 {
                     }
                     [
                         position = 8312, 9784
                     ]
 
-                    component gen_product Product15 {
+                    component "core/Product" Product15 {
                     }
                     [
                         position = 8312, 9880
                     ]
 
-                    component gen_rel_op "Relational operator1" {
+                    component "core/Relational operator" "Relational operator1" {
                         relational_op = ">"
                     }
                     [
@@ -23108,7 +23124,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_probe diff {
+                    component "core/Probe" diff {
                     }
                     [
                         position = 8208, 8168
@@ -23126,7 +23142,7 @@ out = out_value;
                         size = 64, 32
                     ]
 
-                    component pas_resistor Rinb {
+                    component "core/Resistor" Rinb {
                         resistance = "1e10"
                     }
                     [
@@ -23134,7 +23150,7 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_resistor Rina {
+                    component "core/Resistor" Rina {
                         resistance = "1e10"
                     }
                     [
@@ -23142,7 +23158,7 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_resistor Rinc {
+                    component "core/Resistor" Rinc {
                         resistance = "1e10"
                     }
                     [
@@ -23150,7 +23166,7 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_resistor Rmida {
+                    component "core/Resistor" Rmida {
                         resistance = "Rmid"
                     }
                     [
@@ -23159,7 +23175,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component pas_resistor Rmidb {
+                    component "core/Resistor" Rmidb {
                         resistance = "Rmid"
                     }
                     [
@@ -23168,7 +23184,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component pas_resistor Rmidc {
+                    component "core/Resistor" Rmidc {
                         resistance = "Rmid"
                     }
                     [
@@ -23177,7 +23193,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_terminator Termination1 {
+                    component "core/Termination" Termination1 {
                     }
                     [
                         position = 7880, 8328
@@ -25254,7 +25270,7 @@ out = out_value;
                 layout = dynamic
                 component Subsystem Auto1 {
                     layout = static
-                    component el_current_msr Isec_A {
+                    component "core/el_current_msr" Isec_A {
                         execution_rate = "execution_rate"
                         sig_output = "True"
                     }
@@ -25262,21 +25278,21 @@ out = out_value;
                         position = 9256, 8656
                     ]
 
-                    component pas_inductor Lr_A {
+                    component "core/Inductor" Lr_A {
                         inductance = "Lright"
                     }
                     [
                         position = 8896, 8656
                     ]
 
-                    component pas_resistor Rr_A {
+                    component "core/Resistor" Rr_A {
                         resistance = "Rright"
                     }
                     [
                         position = 8800, 8656
                     ]
 
-                    component pas_inductor Lm_A {
+                    component "core/Inductor" Lm_A {
                         inductance = "Lm"
                     }
                     [
@@ -25284,7 +25300,7 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_resistor Rm_A {
+                    component "core/Resistor" Rm_A {
                         resistance = "Rm"
                     }
                     [
@@ -25292,14 +25308,14 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_inductor Ll_A {
+                    component "core/Inductor" Ll_A {
                         inductance = "Lleft"
                     }
                     [
                         position = 8160, 8656
                     ]
 
-                    component pas_resistor Rl_A {
+                    component "core/Resistor" Rl_A {
                         resistance = "Rleft"
                     }
                     [
@@ -25308,7 +25324,7 @@ out = out_value;
 
                     component Subsystem "Elapsed Time" {
                         layout = dynamic
-                        component src_clock Clock1 {
+                        component "core/Clock" Clock1 {
                             execution_rate = "execution_rate"
                         }
                         [
@@ -25316,15 +25332,16 @@ out = out_value;
                             hide_name = True
                         ]
 
-                        component sys_signal_switch "Signal switch1" {
+                        component "core/Signal switch" "Signal switch1" {
                             criterion = "ctrl >= threshold"
+                            threshold = "0.5"
                         }
                         [
                             position = 8200, 8184
                             hide_name = True
                         ]
 
-                        component tm_delay "Unit Delay1" {
+                        component "core/Unit Delay" "Unit Delay1" {
                         }
                         [
                             position = 8200, 8240
@@ -25342,7 +25359,7 @@ out = out_value;
                             size = 32, 32
                         ]
 
-                        component gen_sum Sum2 {
+                        component "core/Sum" Sum2 {
                             signs = "-+"
                         }
                         [
@@ -25410,7 +25427,7 @@ out = out_value;
                         size = 48, 48
                     ]
 
-                    component src_constant var_per_tap {
+                    component "core/Constant" var_per_tap {
                         execution_rate = "execution_rate"
                         value = "var_per_tap"
                     }
@@ -25418,14 +25435,14 @@ out = out_value;
                         position = 8936, 8328
                     ]
 
-                    component gen_product Product1 {
+                    component "core/Product" Product1 {
                     }
                     [
                         position = 9040, 8264
                         hide_name = True
                     ]
 
-                    component gen_probe tap {
+                    component "core/Probe" tap {
                     }
                     [
                         position = 9112, 8184
@@ -25433,7 +25450,7 @@ out = out_value;
                         scale = -1, -1
                     ]
 
-                    component src_constant regulator_voltage {
+                    component "core/Constant" regulator_voltage {
                         execution_rate = "execution_rate"
                         value = "Vreg"
                     }
@@ -25442,7 +25459,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component src_constant regulator_voltage1 {
+                    component "core/Constant" regulator_voltage1 {
                         execution_rate = "execution_rate"
                         value = "band"
                     }
@@ -25451,7 +25468,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_gain Gain1 {
+                    component "core/Gain" Gain1 {
                         gain = "0.5"
                     }
                     [
@@ -25459,7 +25476,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_sum VSum {
+                    component "core/Sum" VSum {
                         signs = "-+"
                     }
                     [
@@ -25467,21 +25484,21 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_abs Abs1 {
+                    component "core/Abs" Abs1 {
                     }
                     [
                         position = 8032, 8248
                         hide_name = True
                     ]
 
-                    component gen_sign Sign1 {
+                    component "core/Sign" Sign1 {
                     }
                     [
                         position = 8032, 8208
                         hide_name = True
                     ]
 
-                    component src_constant regulator_voltage2 {
+                    component "core/Constant" regulator_voltage2 {
                         execution_rate = "execution_rate"
                         value = "Td"
                     }
@@ -25490,7 +25507,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_rel_op "Relational operator2" {
+                    component "core/Relational operator" "Relational operator2" {
                         relational_op = ">"
                     }
                     [
@@ -25498,7 +25515,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_logic_op "Logical operator1" {
+                    component "core/Logical operator" "Logical operator1" {
                     }
                     [
                         position = 8672, 8288
@@ -25514,14 +25531,14 @@ out = out_value;
                         size = 32, 32
                     ]
 
-                    component gen_logic_op "Logical operator2" {
+                    component "core/Logical operator" "Logical operator2" {
                     }
                     [
                         position = 8448, 8280
                         hide_name = True
                     ]
 
-                    component gen_logic_op "Logical operator3" {
+                    component "core/Logical operator" "Logical operator3" {
                         operator = "NOT"
                     }
                     [
@@ -25530,7 +25547,7 @@ out = out_value;
                         scale = -1, 1
                     ]
 
-                    component gen_product Product2 {
+                    component "core/Product" Product2 {
                     }
                     [
                         position = 8752, 8256
@@ -25555,7 +25572,7 @@ out = out_value;
                         size = 64, 32
                     ]
 
-                    component gen_gain ABcomp {
+                    component "core/Gain" ABcomp {
                         gain = "ABcomp"
                     }
                     [
@@ -25564,7 +25581,7 @@ out = out_value;
                         scale = -1, 1
                     ]
 
-                    component gen_accumulator "Tap Position" {
+                    component "core/Accumulator" "Tap Position" {
                         limit_lower = "-min_n_tap"
                         limit_output = "True"
                         limit_upper = "max_n_tap"
@@ -25573,7 +25590,7 @@ out = out_value;
                         position = 8832, 8256
                     ]
 
-                    component el_voltage_msr Vprim_A {
+                    component "core/el_voltage_msr" Vprim_A {
                         execution_rate = "execution_rate"
                         sig_output = "True"
                     }
@@ -25582,7 +25599,7 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component gen_gain Gain4 {
+                    component "core/Gain" Gain4 {
                         gain = "1/ptratio_auto"
                     }
                     [
@@ -25606,19 +25623,19 @@ out = out_value;
                         size = 64, 32
                     ]
 
-                    component gen_product Product11 {
+                    component "core/Product" Product11 {
                     }
                     [
                         position = 8312, 8872
                     ]
 
-                    component gen_product Product10 {
+                    component "core/Product" Product10 {
                     }
                     [
                         position = 8312, 8968
                     ]
 
-                    component gen_probe per_tap {
+                    component "core/Probe" per_tap {
                     }
                     [
                         position = 9040, 8328
@@ -25626,7 +25643,7 @@ out = out_value;
                         scale = -1, -1
                     ]
 
-                    component gen_probe pu_applied {
+                    component "core/Probe" pu_applied {
                     }
                     [
                         position = 9344, 8192
@@ -25634,7 +25651,7 @@ out = out_value;
                         scale = -1, -1
                     ]
 
-                    component gen_sum VSum1 {
+                    component "core/Sum" VSum1 {
                         signs = "++"
                     }
                     [
@@ -25642,7 +25659,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component src_constant regulator_voltage3 {
+                    component "core/Constant" regulator_voltage3 {
                         execution_rate = "execution_rate"
                     }
                     [
@@ -25650,7 +25667,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_sum VSum2 {
+                    component "core/Sum" VSum2 {
                         signs = "-+"
                     }
                     [
@@ -25658,7 +25675,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component src_constant regulator_voltage4 {
+                    component "core/Constant" regulator_voltage4 {
                         execution_rate = "execution_rate"
                         value = "tap_difference"
                     }
@@ -25667,7 +25684,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_rel_op "Relational operator1" {
+                    component "core/Relational operator" "Relational operator1" {
                         relational_op = ">"
                     }
                     [
@@ -25675,7 +25692,7 @@ out = out_value;
                         hide_name = True
                     ]
 
-                    component gen_probe diff {
+                    component "core/Probe" diff {
                     }
                     [
                         position = 8208, 8168
@@ -25683,7 +25700,7 @@ out = out_value;
                         scale = -1, -1
                     ]
 
-                    component pas_resistor Rina {
+                    component "core/Resistor" Rina {
                         resistance = "1e10"
                     }
                     [
@@ -25691,7 +25708,7 @@ out = out_value;
                         rotation = right
                     ]
 
-                    component pas_resistor Rmida {
+                    component "core/Resistor" Rmida {
                         resistance = "Rmid"
                     }
                     [
@@ -26758,7 +26775,7 @@ out = out_value;
 
                 component "core/Signal switch" "Signal switch20" {
                     criterion = "ctrl >= threshold"
-                    threshold = "0"
+                    threshold = "0.5"
                 }
                 [
                     position = 8200, 8136
@@ -26869,7 +26886,7 @@ out = out_value;
 
                 component "core/Signal switch" "Signal switch23" {
                     criterion = "ctrl >= threshold"
-                    threshold = "0"
+                    threshold = "0.5"
                 }
                 [
                     position = 8272, 7816
@@ -27272,7 +27289,7 @@ if (counter >= Ts) {
 
                 component "core/Signal switch" "Signal switch29" {
                     criterion = "ctrl >= threshold"
-                    threshold = "0"
+                    threshold = "0.5"
                 }
                 [
                     position = 9392, 8608


### PR DESCRIPTION
A new auxiliary component is created.
The auxiliary component "CPL" now uses the auxiliary component "single-phase CPL" as building block.
The library file was updated to clean it up when adding the new aux component.
The capacitor and fault comp scripts needed update to avoid issues on creating connection between nodes that are already connect. Seems to be an issue caused by the library update. Now both components are more robust for changes on the library.

Closes #17 