### PR TITLE
Refactor execution rate variable

### DIFF
--- a/tse_to_opendss/thcc_libs/bus.tlib
+++ b/tse_to_opendss/thcc_libs/bus.tlib
@@ -10,7 +10,7 @@ library "OpenDSS" {
 				IA = "False"
 				IB = "False"
 				IC = "False"
-				Ts = "ts"
+				Ts = "execution_rate"
 				VAn = "False"
 				VBn = "False"
 				VCn = "False"
@@ -360,8 +360,9 @@ library "OpenDSS" {
                     ENDCODE
                 }
 
-                ts {
+                execution_rate {
                     label = "Execution Rate"
+                    previous_names = "ts"
                     widget = edit
                     type = generic
                     default_value = "100e-6"

--- a/tse_to_opendss/thcc_libs/component_scripts/comp_generator.py
+++ b/tse_to_opendss/thcc_libs/component_scripts/comp_generator.py
@@ -37,7 +37,7 @@ def components_and_connections(mdl, mask_handle, created_ports, caller_prop_hand
                                              parent=comp_handle,
                                              position=(6200, 8536))
             mdl.set_property_value(mdl.prop(const_102, "value"), "Ts_switch")
-            mdl.set_property_value(mdl.prop(const_102, "execution_rate"), "Ts")
+            mdl.set_property_value(mdl.prop(const_102, "execution_rate"), "execution_rate")
             mdl.set_property_value(mdl.prop(const_102, "signal_type"), "real")
             # Create Ts_Switch subsystem (used a try/except just to separate the subsystem components)
             try:
@@ -111,7 +111,7 @@ def components_and_connections(mdl, mask_handle, created_ports, caller_prop_hand
             mdl.set_property_value(mdl.prop(ts_module, "T_vec"), "T_Ts_internal")
             mdl.set_property_value(mdl.prop(ts_module, "Tmax"), "T_Ts_max")
             mdl.set_property_value(mdl.prop(ts_module, "Tdel"), "del_Ts + Mech_En")
-            mdl.set_property_value(mdl.prop(ts_module, "Texec"), "Ts")
+            mdl.set_property_value(mdl.prop(ts_module, "Texec"), "execution_rate")
             ext_port = mdl.get_item("T", parent=comp_handle, item_type=ITEM_PORT)
             mdl.create_connection(ext_port, mdl.term(ts_subsystem, "T"))
             mdl.create_connection(mdl.term(const_102, "out"), mdl.term(ts_subsystem, "mode"))
@@ -153,7 +153,7 @@ def components_and_connections(mdl, mask_handle, created_ports, caller_prop_hand
                                                 parent=comp_handle,
                                                 position=(6472, 8400))
                 mdl.set_property_value(mdl.prop(const_33, "value"), "0")
-                mdl.set_property_value(mdl.prop(const_33, "execution_rate"), "Ts")
+                mdl.set_property_value(mdl.prop(const_33, "execution_rate"), "execution_rate")
                 mdl.create_connection(mdl.term(const_33, "out"), mdl.term(bus_join, "in10"))
                 mdl.create_connection(mdl.term(const_33, "out"), mdl.term(bus_join, "in9"))
 

--- a/tse_to_opendss/thcc_libs/component_scripts/comp_load.py
+++ b/tse_to_opendss/thcc_libs/component_scripts/comp_load.py
@@ -226,7 +226,7 @@ def load_model_value_edited_fnc(mdl, container_handle, new_value):
     if new_value == "Constant Impedance":
         mdl.set_property_disp_value(mdl.prop(container_handle, 'Pow_ref_s'), "Fixed")
         mdl.disable_property(mdl.prop(container_handle, "Pow_ref_s"))
-        mdl.disable_property(mdl.prop(container_handle, "Ts"))
+        mdl.disable_property(mdl.prop(container_handle, "execution_rate"))
         mdl.disable_property(mdl.prop(container_handle, "Tfast"))
         mdl.disable_property(mdl.prop(container_handle, "CPL_LMT"))
         mdl.disable_property(mdl.prop(container_handle, "q_gain_k"))
@@ -239,7 +239,7 @@ def load_model_value_edited_fnc(mdl, container_handle, new_value):
             mdl.enable_property(mdl.prop(container_handle, "ground_connected"))
     else:
         mdl.enable_property(mdl.prop(container_handle, "Pow_ref_s"))
-        mdl.enable_property(mdl.prop(container_handle, "Ts"))
+        mdl.enable_property(mdl.prop(container_handle, "execution_rate"))
         mdl.enable_property(mdl.prop(container_handle, "Tfast"))
         mdl.enable_property(mdl.prop(container_handle, "CPL_LMT"))
         mdl.enable_property(mdl.prop(container_handle, "q_gain_k"))

--- a/tse_to_opendss/thcc_libs/component_scripts/comp_vsc.py
+++ b/tse_to_opendss/thcc_libs/component_scripts/comp_vsc.py
@@ -161,7 +161,7 @@ def set_timeseries_switch(mdl, mask_handle, new_value):
             ts_switch = mdl.create_component("Constant", parent=comp_handle,
                                              name="Ts_switch", position=(ref_pos[0], ref_pos[1]))
             mdl.set_property_value(mdl.prop(ts_switch, "value"), "Ts_switch")
-            mdl.set_property_value(mdl.prop(ts_switch, "execution_rate"), "Ts")
+            mdl.set_property_value(mdl.prop(ts_switch, "execution_rate"), "execution_rate")
 
         port_t = mdl.get_item("T", parent=comp_handle, item_type="port")
         if not port_t:
@@ -196,7 +196,7 @@ def set_timeseries_switch(mdl, mask_handle, new_value):
             ts_module = mdl.create_component("OpenDSS/TS_module", parent=comp_handle,
                                              name="TS_module", position=(ref_pos[0] + 456, ref_pos[1] + 48),
                                              rotation="left")
-            mdl.set_property_value(mdl.prop(ts_module, "Texec"), "Ts")
+            mdl.set_property_value(mdl.prop(ts_module, "Texec"), "execution_rate")
             mdl.set_property_value(mdl.prop(ts_module, "P_nom"), "Sinv")
             mdl.set_property_value(mdl.prop(ts_module, "Q_nom"), "Qinv")
 

--- a/tse_to_opendss/thcc_libs/generator.tlib
+++ b/tse_to_opendss/thcc_libs/generator.tlib
@@ -126,7 +126,7 @@ Te_mem = Te;
             ]
 
             component "core/Voltage Measurement" Vc {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -136,7 +136,7 @@ Te_mem = Te;
             ]
 
             component "core/Voltage Measurement" Vb {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -161,7 +161,7 @@ Te_mem = Te;
             ]
 
             component "core/Voltage Measurement" Va {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -201,7 +201,7 @@ Te_mem = Te;
             ]
 
             component "core/Voltage Measurement" Vab {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
             }
             [
                 position = 5392, 8328
@@ -210,7 +210,7 @@ Te_mem = Te;
             ]
 
             component "core/Voltage Measurement" Vbc {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
             }
             [
                 position = 5392, 8424
@@ -219,7 +219,7 @@ Te_mem = Te;
             ]
 
             component "core/Current Measurement" Ia {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -228,7 +228,7 @@ Te_mem = Te;
             ]
 
             component "core/Current Measurement" Ib {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -237,7 +237,7 @@ Te_mem = Te;
             ]
 
             component "core/Current Measurement" Ic {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -246,7 +246,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant3 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "0.0"
             }
             [
@@ -272,8 +272,8 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant4 {
-                execution_rate = "Ts"
-                value = "Ts"
+                execution_rate = "execution_rate"
+                value = "execution_rate"
             }
             [
                 position = 4816, 7416
@@ -288,7 +288,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant5 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "0"
             }
             [
@@ -305,8 +305,8 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant6 {
-                execution_rate = "Ts"
-                value = "0.5/Ts"
+                execution_rate = "execution_rate"
+                value = "0.5/execution_rate"
             }
             [
                 position = 5704, 8120
@@ -388,7 +388,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant13 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "ws/PP"
             }
             [
@@ -466,7 +466,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant14 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "0.0"
             }
             [
@@ -568,7 +568,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant18 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "Init_switch"
             }
             [
@@ -600,7 +600,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant19 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "thet_ph_init"
             }
             [
@@ -609,7 +609,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant20 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "V_ph_init"
             }
             [
@@ -626,7 +626,7 @@ Te_mem = Te;
             ]
 
             component "core/Clock" Clock1 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
             }
             [
                 position = 5560, 7408
@@ -635,7 +635,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant21 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "V2M_t"
             }
             [
@@ -644,7 +644,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant23 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "Mech_En"
             }
             [
@@ -653,7 +653,7 @@ Te_mem = Te;
             ]
 
             component "core/Rate Transition" "Rate Transition1" {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
             }
             [
                 position = 4240, 7712
@@ -662,7 +662,7 @@ Te_mem = Te;
             ]
 
             component "core/Rate Transition" "Rate Transition2" {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
             }
             [
                 position = 4240, 7768
@@ -671,7 +671,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant24 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "Init_switch"
             }
             [
@@ -700,7 +700,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant25 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
             }
             [
                 position = 4608, 7936
@@ -708,7 +708,7 @@ Te_mem = Te;
             ]
 
             component "core/Voltage Measurement" Vca {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
             }
             [
                 position = 5448, 8424
@@ -725,7 +725,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant26 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "Init_switch"
             }
             [
@@ -743,7 +743,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant27 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "kw"
             }
             [
@@ -752,7 +752,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant28 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "kvar"
             }
             [
@@ -761,7 +761,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant29 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "kv"
             }
             [
@@ -770,7 +770,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant30 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "PP"
             }
             [
@@ -779,7 +779,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant31 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "ws"
             }
             [
@@ -824,7 +824,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant32 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "gen_ts_en_bit"
             }
             [
@@ -833,7 +833,7 @@ Te_mem = Te;
             ]
 
             component "core/Constant" Constant33 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "0"
             }
             [
@@ -2369,7 +2369,8 @@ Te_mem = Te;
                     no_evaluate
                 }
 
-                Ts {
+                execution_rate {
+                    previous_names = "Ts"
                     label = "Execution rate"
                     widget = edit
                     type = generic
@@ -3027,7 +3028,7 @@ Te_mem = Te;
                     ws_inv = mdl.get_property_value(mdl.prop(item_handle, "ws_inv"))
                     Z_base = mdl.get_property_value(mdl.prop(item_handle, "Z_base"))
                     G_mod = mdl.get_property_value(mdl.prop(item_handle, "G_mod"))
-                    Ts = mdl.get_property_value(mdl.prop(item_handle, "Ts"))
+                    execution_rate = mdl.get_property_value(mdl.prop(item_handle, "execution_rate"))
                     dA = mdl.get_property_value(mdl.prop(item_handle, "dA"))
                     dB = mdl.get_property_value(mdl.prop(item_handle, "dB"))
                     dA11 = mdl.get_property_value(mdl.prop(item_handle, "dA11"))
@@ -3197,8 +3198,8 @@ Te_mem = Te;
                     A = numpy.matrix(A)
                     B = numpy.matrix(B)
 
-                    dA = numpy.linalg.inv((numpy.eye(4)-(0.5*Ts)*A)) * ((numpy.eye(4)+(0.5*Ts)*A))
-                    dB = numpy.linalg.inv((numpy.eye(4)-(0.5*Ts)*A)) * (Ts*B)
+                    dA = numpy.linalg.inv((numpy.eye(4)-(0.5*execution_rate)*A)) * ((numpy.eye(4)+(0.5*execution_rate)*A))
+                    dB = numpy.linalg.inv((numpy.eye(4)-(0.5*execution_rate)*A)) * (execution_rate*B)
 
                     dA11=dA[0, 0]
                     dA12=dA[0, 1]
@@ -3263,7 +3264,7 @@ Te_mem = Te;
                     mdl.set_property_value(mdl.prop(item_handle, "dB42"), dB42)
                     mdl.set_property_value(mdl.prop(item_handle, "dB43"), dB43)
 
-                    mdl.set_property_value(mdl.prop(item_handle, "Ts"), Ts)
+                    mdl.set_property_value(mdl.prop(item_handle, "execution_rate"), execution_rate)
                     mdl.set_property_value(mdl.prop(item_handle, "basefreq"), basefreq)
                     mdl.set_property_value(mdl.prop(item_handle, "ws"), ws)
                     mdl.set_property_value(mdl.prop(item_handle, "ws_inv"), ws_inv)

--- a/tse_to_opendss/thcc_libs/load.tlib
+++ b/tse_to_opendss/thcc_libs/load.tlib
@@ -366,7 +366,8 @@ library "OpenDSS" {
                     ENDCODE
                 }
 
-                Ts {
+                execution_rate {
+                    previous_names = "Ts"
                     label = "CPL Execution rate"
                     widget = edit
                     type = generic
@@ -378,7 +379,7 @@ library "OpenDSS" {
                     CODE property_value_changed
                         comp_handle = mdl.get_sub_level_handle(container_handle)
                         Tfst_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "Tfast"))
-                        Ts_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "Ts"))
+                        Ts_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "execution_rate"))
                         CPL_comp = mdl.get_item("CPL", parent=comp_handle, item_type="component")
 
                         if CPL_comp:
@@ -401,7 +402,7 @@ library "OpenDSS" {
 
                     CODE property_value_changed
                         comp_handle = mdl.get_sub_level_handle(container_handle)
-                        Ts_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "Ts"))
+                        Ts_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "execution_rate"))
                         Tfst_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "Tfast"))
                         CPL_comp = mdl.get_item("CPL", parent=comp_handle, item_type="component")
 
@@ -821,7 +822,7 @@ library "OpenDSS" {
                     load_model = mdl.get_property_value(mdl.prop(item_handle, "load_model"))
                     model = mdl.get_property_value(mdl.prop(item_handle, "model"))
                     Pow_ref_s = mdl.get_property_value(mdl.prop(item_handle, "Pow_ref_s"))
-                    Ts = mdl.get_property_value(mdl.prop(item_handle, "Ts"))
+                    execution_rate = mdl.get_property_value(mdl.prop(item_handle, "execution_rate"))
                     Tfast = mdl.get_property_value(mdl.prop(item_handle, "Tfast"))
                     CPL_LMT = mdl.get_property_value(mdl.prop(item_handle, "CPL_LMT"))
                     q_gain_k = mdl.get_property_value(mdl.prop(item_handle, "q_gain_k"))
@@ -969,7 +970,7 @@ library "OpenDSS" {
                     mdl.set_property_value(mdl.prop(item_handle, "kV"), kV)
                     mdl.set_property_value(mdl.prop(item_handle, "load_model"), load_model)
                     mdl.set_property_value(mdl.prop(item_handle, "model"), model)
-                    mdl.set_property_value(mdl.prop(item_handle, "Ts"), Ts)
+                    mdl.set_property_value(mdl.prop(item_handle, "execution_rate"), execution_rate)
                     mdl.set_property_value(mdl.prop(item_handle, "Sn_3ph"), Sn_3ph)
 
                     mdl.set_property_value(mdl.prop(item_handle, "Tfast"), Tfast)

--- a/tse_to_opendss/thcc_libs/opendss_lib.tlib
+++ b/tse_to_opendss/thcc_libs/opendss_lib.tlib
@@ -1249,7 +1249,7 @@ library "OpenDSS" {
             component Subsystem CPL {
                 layout = dynamic
                 component "core/Constant" Constant1 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "kP_tot"
                 }
                 [
@@ -1258,7 +1258,7 @@ library "OpenDSS" {
                 ]
 
                 component "core/Constant" Constant11 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "kQ_tot"
                 }
                 [
@@ -1283,7 +1283,7 @@ library "OpenDSS" {
                 ]
 
                 component "OpenDSS/Rate Transition with Bypass" "Rate Transition with Bypass1" {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                 }
                 [
                     position = 7792, 7456
@@ -1292,7 +1292,7 @@ library "OpenDSS" {
                 ]
 
                 component "OpenDSS/Rate Transition with Bypass" "Rate Transition with Bypass2" {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                 }
                 [
                     position = 7680, 7584
@@ -1710,11 +1710,12 @@ library "OpenDSS" {
                         nonvisible
                     }
 
-                    Ts {
+                    execution_rate {
+                        previous_names = "Ts"
                         label = "Execution Rate"
                         widget = edit
                         type = generic
-                        default_value = "Ts"
+                        default_value = "execution_rate"
                         unit = "s"
                         group = "Execution rate:2"
                     }
@@ -1733,7 +1734,7 @@ library "OpenDSS" {
                             rate_trans1 = mdl.get_item("Rate Transition with Bypass1", parent=comp_handle, item_type="component")
                             rate_trans2 = mdl.get_item("Rate Transition with Bypass2", parent=comp_handle, item_type="component")
                             Tfst_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "Tfst"))
-                            Ts_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "Ts"))
+                            Ts_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "execution_rate"))
                             P_inp_mask = mdl.get_property_value(mdl.prop(container_handle, "kP_inp"))
                             Q_inp_mask = mdl.get_property_value(mdl.prop(container_handle, "kQ_inp"))
 
@@ -2001,7 +2002,7 @@ library "OpenDSS" {
                         kQ_tot = mdl.get_property_value(mdl.prop(item_handle, "kQ_tot"))
                         kQ = mdl.get_property_value(mdl.prop(item_handle, "kQ"))
                         Q = mdl.get_property_value(mdl.prop(item_handle, "Q"))
-                        Ts = mdl.get_property_value(mdl.prop(item_handle, "Ts"))
+                        execution_rate = mdl.get_property_value(mdl.prop(item_handle, "execution_rate"))
                         Fast_con = mdl.get_property_value(mdl.prop(item_handle, "Fast_con"))
                         Tfst = mdl.get_property_value(mdl.prop(item_handle, "Tfst"))
                         Tfast_en = mdl.get_property_value(mdl.prop(item_handle, "Tfast_en"))
@@ -2049,8 +2050,8 @@ library "OpenDSS" {
                         pQc_P = -1/9.7
                         nQc_P = -0.097
 
-                        pQc_T = -0.015*(Ts-600e-6)/Ts
-                        nQc_T = -0.012*(Ts-600e-6)/Ts
+                        pQc_T = -0.015*(execution_rate-600e-6)/execution_rate
+                        nQc_T = -0.012*(execution_rate-600e-6)/execution_rate
 
                         pQc_Q = 0.0266
                         nQc_Q = 0.014
@@ -2058,10 +2059,10 @@ library "OpenDSS" {
                         Pc_pQ = 0.095
                         Pc_nQ = 0.0933
 
-                        Pc_T = 0.005*(Ts-600e-6)/Ts
+                        Pc_T = 0.005*(execution_rate-600e-6)/execution_rate
 
-                        Pc_T_pQ = 0.0075*(Ts-600e-6)/Ts
-                        Pc_T_nQ = 0.01*(Ts-600e-6)/Ts
+                        Pc_T_pQ = 0.0075*(execution_rate-600e-6)/execution_rate
+                        Pc_T_nQ = 0.01*(execution_rate-600e-6)/execution_rate
 
                         Fc = -0*1/15
 
@@ -2079,7 +2080,7 @@ library "OpenDSS" {
                         mdl.set_property_value(mdl.prop(item_handle, "Rsnb"), Rsnb)
                         mdl.set_property_value(mdl.prop(item_handle, "kQ"), kQ)
                         mdl.set_property_value(mdl.prop(item_handle, "Q"), Q)
-                        mdl.set_property_value(mdl.prop(item_handle, "Ts"), Ts)
+                        mdl.set_property_value(mdl.prop(item_handle, "execution_rate"), execution_rate)
                         mdl.set_property_value(mdl.prop(item_handle, "kP_tot"), kP_tot)
                         mdl.set_property_value(mdl.prop(item_handle, "kQ_tot"), kQ_tot)
                         mdl.set_property_value(mdl.prop(item_handle, "Tfast_en"), Tfast_en)
@@ -6916,7 +6917,7 @@ library "OpenDSS" {
 						label = "Execution Rate"
 						widget = edit
 						type = generic
-						default_value = "Ts"
+						default_value = "execution_rate"
 
 						CODE property_value_changed
                             comp_handle = mdl.get_sub_level_handle(container_handle)
@@ -7048,15 +7049,15 @@ library "OpenDSS" {
 
 	}
 	else {
-		corr = 1 - 0.11 * (Ts - Ts_fast)/Ts;
-		m2 = (zi - zii)/Ts;
-		m1 = (z - zi)/Ts;
+		corr = 1 - 0.11 * (execution_rate - Ts_fast)/execution_rate;
+		m2 = (zi - zii)/execution_rate;
+		m1 = (z - zi)/execution_rate;
 		m0 = m1 + (m1-m2);
 
 		out = z + counter * corr * m0;
 	}
 
-	if (counter >= Ts) {
+	if (counter >= execution_rate) {
 		counter = 0;
 	}
 	/*End code section*/"
@@ -7086,7 +7087,7 @@ library "OpenDSS" {
 
 				component "core/Constant" Constant21 {
 					execution_rate = "Tfst"
-					value = "Ts"
+					value = "execution_rate"
 				}
 				[
 					position = 8080, 9112
@@ -7395,7 +7396,7 @@ library "OpenDSS" {
 
 				component "core/Constant" Constant29 {
 					execution_rate = "Tfst"
-					value = "Ts"
+					value = "execution_rate"
 				}
 				[
 					position = 8256, 9096
@@ -8223,11 +8224,12 @@ library "OpenDSS" {
                         nonvisible
                     }
 
-                    Ts {
+                    execution_rate {
+                        previous_names = "Ts"
                         label = "Execution Rate"
                         widget = edit
                         type = generic
-                        default_value = "Ts"
+                        default_value = "execution_rate"
                         unit = "s"
                         group = "Execution rate:2"
 
@@ -8246,7 +8248,7 @@ library "OpenDSS" {
                             rate_trans1 = mdl.get_item("Rate Transition with Bypass1", parent=comp_handle, item_type="component")
                             rate_trans2 = mdl.get_item("Rate Transition with Bypass2", parent=comp_handle, item_type="component")
                             rate_trans3 = mdl.get_item("Rate Transition with Bypass3", parent=comp_handle, item_type="component")
-                            Ts_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "Ts"))
+                            Ts_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "execution_rate"))
                             Tfst_mask = mdl.get_property_disp_value(mdl.prop(container_handle, "Tfst"))
 
                             if new_value and not Ts_mask == Tfst_mask:
@@ -8428,7 +8430,7 @@ library "OpenDSS" {
                         kQ_tot = mdl.get_property_value(mdl.prop(item_handle, "kQ_tot"))
                         kQ = mdl.get_property_value(mdl.prop(item_handle, "kQ"))
                         Q = mdl.get_property_value(mdl.prop(item_handle, "Q"))
-                        Ts = mdl.get_property_value(mdl.prop(item_handle, "Ts"))
+                        execution_rate = mdl.get_property_value(mdl.prop(item_handle, "execution_rate"))
                         Fast_con = mdl.get_property_value(mdl.prop(item_handle, "Fast_con"))
                         Tfst = mdl.get_property_value(mdl.prop(item_handle, "Tfst"))
                         Tfast_en = mdl.get_property_value(mdl.prop(item_handle, "Tfast_en"))
@@ -8475,8 +8477,8 @@ library "OpenDSS" {
                         pQc_P = -1/9.7
                         nQc_P = -0.097
 
-                        pQc_T = -0.015*(Ts-600e-6)/Ts
-                        nQc_T = -0.012*(Ts-600e-6)/Ts
+                        pQc_T = -0.015*(execution_rate-600e-6)/execution_rate
+                        nQc_T = -0.012*(execution_rate-600e-6)/execution_rate
 
                         pQc_Q = 0.0266
                         nQc_Q = 0.014
@@ -8484,10 +8486,10 @@ library "OpenDSS" {
                         Pc_pQ = 0.095
                         Pc_nQ = 0.0933
 
-                        Pc_T = 0.005*(Ts-600e-6)/Ts
+                        Pc_T = 0.005*(execution_rate-600e-6)/execution_rate
 
-                        Pc_T_pQ = 0.0075*(Ts-600e-6)/Ts
-                        Pc_T_nQ = 0.01*(Ts-600e-6)/Ts
+                        Pc_T_pQ = 0.0075*(execution_rate-600e-6)/execution_rate
+                        Pc_T_nQ = 0.01*(execution_rate-600e-6)/execution_rate
 
                         Fc = -0*1/15
 
@@ -8499,7 +8501,7 @@ library "OpenDSS" {
                         mdl.set_property_value(mdl.prop(item_handle, "Rsnb"), Rsnb)
                         mdl.set_property_value(mdl.prop(item_handle, "kQ"), kQ)
                         mdl.set_property_value(mdl.prop(item_handle, "Q"), Q)
-                        mdl.set_property_value(mdl.prop(item_handle, "Ts"), Ts)
+                        mdl.set_property_value(mdl.prop(item_handle, "execution_rate"), execution_rate)
                         mdl.set_property_value(mdl.prop(item_handle, "kP_tot"), kP_tot)
                         mdl.set_property_value(mdl.prop(item_handle, "kQ_tot"), kQ_tot)
                         mdl.set_property_value(mdl.prop(item_handle, "Tfast_en"), Tfast_en)

--- a/tse_to_opendss/thcc_libs/vsconverter.tlib
+++ b/tse_to_opendss/thcc_libs/vsconverter.tlib
@@ -16,7 +16,7 @@ library "OpenDSS" {
             ]
 
             component "core/Constant" Constant3 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "0"
             }
             [
@@ -117,7 +117,7 @@ library "OpenDSS" {
             ]
 
             component "core/Constant" Constant4 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "0"
             }
             [
@@ -187,7 +187,7 @@ library "OpenDSS" {
             ]
 
             component "core/Constant" Constant5 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "0"
             }
             [
@@ -246,7 +246,7 @@ library "OpenDSS" {
             ]
 
             component "core/Constant" Constant9 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "ext_mode"
             }
             [
@@ -396,7 +396,7 @@ else {
             ]
 
             component "core/Constant" Constant13 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "ctrl_mode_int"
             }
             [
@@ -464,7 +464,7 @@ else {
             ]
 
             component "core/Constant" Constant14 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
             }
             [
                 position = 6688, 9200
@@ -548,7 +548,7 @@ else {
             ]
 
             component "core/Current Measurement" Ia {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -557,7 +557,7 @@ else {
             ]
 
             component "core/Current Measurement" Ib {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -566,7 +566,7 @@ else {
             ]
 
             component "core/Current Measurement" Ic {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -575,7 +575,7 @@ else {
             ]
 
             component "core/Voltage Measurement" Va {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -585,7 +585,7 @@ else {
             ]
 
             component "core/Voltage Measurement" Vb {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -595,7 +595,7 @@ else {
             ]
 
             component "core/Voltage Measurement" Vc {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -707,7 +707,7 @@ else {
                 ]
 
                 component "core/Constant" Constant5 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "0"
                 }
                 [
@@ -741,7 +741,7 @@ else {
                 ]
 
                 component "core/Constant" Constant6 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "0.001"
                 }
                 [
@@ -750,7 +750,7 @@ else {
                 ]
 
                 component "core/Constant" Constant7 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "0"
                 }
                 [
@@ -783,7 +783,7 @@ else {
                 ]
 
                 component "core/Constant" Constant8 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "np.pi"
                 }
                 [
@@ -816,7 +816,7 @@ else {
                 ]
 
                 component "core/Constant" Constant9 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "-np.pi"
                 }
                 [
@@ -825,7 +825,7 @@ else {
                 ]
 
                 component "core/Constant" Constant10 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "0"
                 }
                 [
@@ -1031,7 +1031,7 @@ else {
             ]
 
             component "core/Clock" Clock1 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
             }
             [
                 position = 8080, 8256
@@ -1039,7 +1039,7 @@ else {
             ]
 
             component "core/Constant" Constant21 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "cont_t"
             }
             [
@@ -1048,7 +1048,7 @@ else {
             ]
 
             component "core/Constant" Constant22 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "Sinv"
             }
             [
@@ -1057,7 +1057,7 @@ else {
             ]
 
             component "core/Constant" Constant23 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "Qinv"
             }
             [
@@ -1066,7 +1066,7 @@ else {
             ]
 
             component "core/Constant" Constant24 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "Fs"
             }
             [
@@ -1075,7 +1075,7 @@ else {
             ]
 
             component "core/Constant" Constant25 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "vac_set"
             }
             [
@@ -1092,7 +1092,7 @@ else {
             ]
 
             component "core/Constant" Constant27 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "0"
             }
             [
@@ -1110,7 +1110,7 @@ else {
             ]
 
             component "core/Constant" Constant28 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "2*np.pi"
             }
             [
@@ -1147,8 +1147,8 @@ out_mem = out;
             ]
 
             component "core/Constant" Constant30 {
-                execution_rate = "Ts"
-                value = "Ts"
+                execution_rate = "execution_rate"
+                value = "execution_rate"
             }
             [
                 position = 7056, 8360
@@ -1165,8 +1165,8 @@ out_mem = out;
             ]
 
             component "core/Constant" Constant31 {
-                execution_rate = "Ts"
-                value = "Ts*Fs*2*np.pi"
+                execution_rate = "execution_rate"
+                value = "execution_rate*Fs*2*np.pi"
             }
             [
                 position = 8664, 8960
@@ -1224,7 +1224,7 @@ out_mem = out;
             ]
 
             component "core/Constant" Constant38 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "0"
             }
             [
@@ -1251,7 +1251,7 @@ out_mem = out;
             ]
 
             component "core/Constant" Constant39 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "0"
             }
             [
@@ -1459,7 +1459,7 @@ if (Vdc<-2) {
             ]
 
             component "core/Voltage Measurement" Va1 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 sig_output = "True"
             }
             [
@@ -1540,7 +1540,7 @@ if (Vdc<-2) {
                 ]
 
                 component "core/Constant" Constant5 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "0"
                 }
                 [
@@ -1574,7 +1574,7 @@ if (Vdc<-2) {
                 ]
 
                 component "core/Constant" Constant6 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "0.001"
                 }
                 [
@@ -1583,7 +1583,7 @@ if (Vdc<-2) {
                 ]
 
                 component "core/Constant" Constant7 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "0"
                 }
                 [
@@ -1616,7 +1616,7 @@ if (Vdc<-2) {
                 ]
 
                 component "core/Constant" Constant8 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "np.pi"
                 }
                 [
@@ -1649,7 +1649,7 @@ if (Vdc<-2) {
                 ]
 
                 component "core/Constant" Constant9 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "-np.pi"
                 }
                 [
@@ -1658,7 +1658,7 @@ if (Vdc<-2) {
                 ]
 
                 component "core/Constant" Constant10 {
-                    execution_rate = "Ts"
+                    execution_rate = "execution_rate"
                     value = "0"
                 }
                 [
@@ -1949,7 +1949,7 @@ if (Vdc<-2) {
             ]
 
             component "core/Constant" Constant43 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
             }
             [
                 position = 9688, 8952
@@ -1988,7 +1988,7 @@ if (Vdc<-2) {
             ]
 
             component "core/Constant" Constant44 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "vdc_set"
             }
             [
@@ -2046,7 +2046,7 @@ if (Vdc<-2) {
             ]
 
             component "core/Constant" Constant45 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "0"
             }
             [
@@ -2124,7 +2124,7 @@ if (Vdc<-2) {
             ]
 
             component "core/Constant" Constant47 {
-                execution_rate = "Ts"
+                execution_rate = "execution_rate"
                 value = "vac_set"
             }
             [
@@ -4331,7 +4331,8 @@ if (Vdc<-2) {
                     group = "Inverter Parameters"
                 }
 
-                Ts {
+                execution_rate {
+                    previous_names = "Ts"
                     label = "Execution rate"
                     widget = edit
                     type = generic
@@ -4779,7 +4780,7 @@ if (Vdc<-2) {
                     Qinv = mdl.get_property_value(mdl.prop(item_handle, "Qinv"))
                     Rac = mdl.get_property_value(mdl.prop(item_handle, "Rac"))
                     Lac = mdl.get_property_value(mdl.prop(item_handle, "Lac"))
-                    Ts = mdl.get_property_value(mdl.prop(item_handle, "Ts"))
+                    execution_rate = mdl.get_property_value(mdl.prop(item_handle, "execution_rate"))
                     cont_t = mdl.get_property_value(mdl.prop(item_handle, "cont_t"))
                     dss_ctrl = mdl.get_property_value(mdl.prop(item_handle, "dss_ctrl"))
                     Phases = mdl.get_property_value(mdl.prop(item_handle, "Phases"))
@@ -4923,7 +4924,7 @@ if (Vdc<-2) {
                     mdl.set_property_value(mdl.prop(item_handle, "V_sel"), V_sel)
                     mdl.set_property_value(mdl.prop(item_handle, "ctrl_mode_int"), ctrl_mode_int)
                     mdl.set_property_value(mdl.prop(item_handle, "ext_mode"), ext_mode)
-                    mdl.set_property_value(mdl.prop(item_handle, "Ts"), Ts)
+                    mdl.set_property_value(mdl.prop(item_handle, "execution_rate"), execution_rate)
                     mdl.set_property_value(mdl.prop(item_handle, "cont_t"), cont_t)
                     mdl.set_property_value(mdl.prop(item_handle, "Sinv"), Sinv)
                     mdl.set_property_value(mdl.prop(item_handle, "Qinv"), Qinv)


### PR DESCRIPTION
Adopts the standard "execution_rate" variable as the proper variable to be used on all components. Components that are multi-rate will have "execution_rate" as the main execution rate of the model.