### PR TITLE
Correcting the importer references to bus' properties that changed name.

### DIFF
--- a/tse_to_opendss/importer/scripts/modules.py
+++ b/tse_to_opendss/importer/scripts/modules.py
@@ -651,9 +651,9 @@ def generateSchematic(comp_dict, placement_info):
                     bus_type += 'A' if '1' in bus_phases else ''
                     bus_type += 'B' if '2' in bus_phases else ''
                     bus_type += 'C' if '3' in bus_phases else ''
-                    model.set_property_value(model.prop(comp_handle, 'type'), bus_type)
+                    model.set_property_value(model.prop(comp_handle, 'type_prop'), bus_type)
                     if '0' in bus_phases:
-                        model.set_property_value(model.prop(comp_handle, 'ground'), True)
+                        model.set_property_value(model.prop(comp_handle, 'ground_prop'), True)
                         
                 else:
                     comp_props = comp['properties']


### PR DESCRIPTION
This branch fixes the references to bus' properties that had the name changed.
This should remove exceptions on the process of placing components on the schematic, but might not fully fix the importer.
Further fixes/improvements should be investigated and covered on another branch/pull request.