### PR TITLE
Update to generator.tlib

### DIFF
--- a/dss_thcc_lib/generator.tlib
+++ b/dss_thcc_lib/generator.tlib
@@ -510,7 +510,7 @@ Te_mem = Te;
 
             component "core/Discrete Transfer Function" "Discrete Transfer Function1" {
                 b_coeff = "[1]"
-                a_coeff = "[0.1,1]"
+                a_coeff = "[0.001,1]"
                 domain = "S-domain"
                 method = "Euler"
             }


### PR DESCRIPTION
updated the denominator of the stator current derivation filter to a better tuned value. This is separate from the critical fix that was applied to the nominator part earlier.